### PR TITLE
phases 1–6 bootstrap

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## What changed / Why
+-
+
+## Weekly report
+[Link to weekly report](https://example.com)
+
+## Acceptance Checkboxes (Phases 1–6)
+[ ] Phase 1 — Scaffolding & Governance: doctor runs < 30s; run registry + seed policy in place
+[ ] Phase 2 — Data Spine: staged/ dir created; contracts module stub with schema and join-key assertions; ingest target no-ops cleanly without data
+[ ] Phase 3 — Feature Store v1: Polars lazy pipeline stubs + leakage guard + PSI hook; features target no-ops cleanly
+[ ] Phase 4 — Baseline Model: training stub with forward-chaining CV placeholder; calibration plot scaffold; no odds usage
+[ ] Phase 5 — Bayesian Team Strength: module stub with recency decay config; returns dummy θ table with CI fields
+[ ] Phase 6 — Simulation Engine v1: run.py sim stub with QMC/CI interfaces and early-stop hooks; emits fair ladder placeholders

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,24 @@
-name: a22a-ci
-on: [push, pull_request]
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
-      - run: python -m pip install --upgrade pip
-      - run: |
-          if [ -f pyproject.toml ]; then pip install .; else pip install -r requirements.txt; fi
-      - name: Doctor
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev]
+      - name: Run doctor
         run: python -m a22a.tools.doctor --ci
-      - name: Unit tests
-        run: python -m pytest -q
+      - name: Run tests
+        run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .env
-data/*
-.venv
-__pycache__
+.venv/
+/data/
+__pycache__/
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,21 @@
-.PHONY: doctor ingest features train sim picks report
+.PHONY: doctor ingest features train sim report
+
+PYTHON ?= python
+
 doctor:
-	python -m a22a.tools.doctor
+	$(PYTHON) -m a22a.tools.doctor
+
 ingest:
-	python -m a22a.data.ingest
+	$(PYTHON) -m a22a.data.ingest
+
 features:
-	python -m a22a.features.build
+	$(PYTHON) -m a22a.features.build
+
 train:
-	python -m a22a.models.train_baseline
+	$(PYTHON) -m a22a.models.train_baseline
+
 sim:
-	python -m a22a.sim.run
+	$(PYTHON) -m a22a.sim.run
+
 report:
-	python -m a22a.reports.weekly
+	$(PYTHON) -m a22a.reports.weekly

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # All-22 Atlas (A22A)
 
-https://drive.google.com/drive/folders/191Q7_8HUyD5l4RNRQF6jjY2OczYqR-id
+All-22 Atlas is a modular analytics platform for orchestrating data ingestion, feature engineering, baseline modelling, and simulation workflows for American football research while maintaining strict governance over seeds, configs, and operational SLOs. This bootstrap repo ships lightweight scaffolding for the first six phases so teams can iterate safely before data arrives.
+
+## Quickstart
+1. Create a virtual environment with Python 3.11 and install dependencies via `pip install -e .`.
+2. Copy `.env.sample` to `.env` and populate API keys.
+3. Run `make doctor` to verify the environment and governance scaffolding.
+4. Use the remaining make targets (`ingest`, `features`, `train`, `sim`, `report`) as you flesh out each phase.

--- a/a22a/__init__.py
+++ b/a22a/__init__.py
@@ -1,0 +1,10 @@
+"""All-22 Atlas bootstrap package."""
+
+__all__ = [
+    "tools",
+    "data",
+    "features",
+    "models",
+    "sim",
+    "reports",
+]

--- a/a22a/data/contracts.py
+++ b/a22a/data/contracts.py
@@ -1,0 +1,56 @@
+"""Data contracts for staged inputs."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Sequence
+
+STAGED_GAME_SCHEMA = {
+    "game_id": str,
+    "season": int,
+    "week": int,
+    "team_id": str,
+    "opponent_id": str,
+}
+
+JOIN_KEYS = {"game_id", "team_id"}
+
+
+@dataclass
+class ContractViolation(Exception):
+    message: str
+    record_index: int
+
+
+def assert_schema(records: Sequence[Mapping[str, object]]) -> None:
+    for idx, record in enumerate(records):
+        missing = STAGED_GAME_SCHEMA.keys() - record.keys()
+        if missing:
+            raise ContractViolation(f"Missing fields: {sorted(missing)}", idx)
+        for column, expected_type in STAGED_GAME_SCHEMA.items():
+            value = record[column]
+            if value is None:
+                raise ContractViolation(f"Column '{column}' cannot be None", idx)
+            if not isinstance(value, expected_type):
+                raise ContractViolation(
+                    f"Column '{column}' expected {expected_type.__name__}, got {type(value).__name__}",
+                    idx,
+                )
+        if not JOIN_KEYS.issubset(record.keys()):
+            raise ContractViolation("Missing join keys", idx)
+
+
+def validate_records(records: Iterable[Mapping[str, object]]) -> bool:
+    """Validate staged records against the contract schema."""
+    records = list(records)
+    if not records:
+        return True
+    assert_schema(records)
+    return True
+
+
+def main() -> None:
+    print("Data contracts module provides schema validation for staged inputs.")
+
+
+if __name__ == "__main__":
+    main()

--- a/a22a/data/ingest.py
+++ b/a22a/data/ingest.py
@@ -1,0 +1,37 @@
+"""ETL ingest scaffolding."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Mapping
+
+from .contracts import JOIN_KEYS, STAGED_GAME_SCHEMA, validate_records
+
+STAGED_DIR = Path("staged")
+
+
+def ensure_staged_dir() -> Path:
+    STAGED_DIR.mkdir(exist_ok=True)
+    return STAGED_DIR
+
+
+def load_raw_sources() -> Iterable[Mapping[str, object]]:
+    """Placeholder for upstream extraction."""
+    return []
+
+
+def apply_contract(records: Iterable[Mapping[str, object]]) -> bool:
+    return validate_records(records)
+
+
+def main() -> None:
+    ensure_staged_dir()
+    records = list(load_raw_sources())
+    if not records:
+        print("[ingest] no upstream data detected; ETL noop")
+    else:
+        apply_contract(records)
+        print(f"[ingest] staged {len(records)} records with schema {list(STAGED_GAME_SCHEMA)} and joins {JOIN_KEYS}")
+
+
+if __name__ == "__main__":
+    main()

--- a/a22a/features/build.py
+++ b/a22a/features/build.py
@@ -1,0 +1,54 @@
+"""Feature store scaffolding with leakage guard and PSI hook."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import polars as pl
+
+STAGED_DIR = Path("staged")
+FEATURE_OUTPUT = Path("data") / "features.parquet"
+
+
+def leakage_guard(features: pl.LazyFrame) -> None:
+    required = {"game_id", "team_id"}
+    if not required.issubset(set(features.columns)):
+        missing = required - set(features.columns)
+        raise ValueError(f"Leakage guard failed: missing {missing}")
+
+
+def compute_psi(reference: pl.DataFrame, current: pl.DataFrame) -> Optional[float]:
+    if reference.is_empty() or current.is_empty():
+        return None
+    return 0.0
+
+
+def build_feature_view() -> pl.LazyFrame:
+    base = pl.DataFrame(
+        {
+            "game_id": ["G-000"],
+            "team_id": ["T-000"],
+            "dummy_metric": [0.0],
+        }
+    ).lazy()
+    return base
+
+
+def materialize(features: pl.LazyFrame) -> None:
+    FEATURE_OUTPUT.parent.mkdir(exist_ok=True)
+    features.collect().write_parquet(FEATURE_OUTPUT)
+
+
+def main() -> None:
+    STAGED_DIR.mkdir(exist_ok=True)
+    features = build_feature_view()
+    leakage_guard(features)
+    reference = pl.DataFrame()
+    current = features.collect()
+    psi = compute_psi(reference, current)
+    materialize(features)
+    print("[features] built lazy feature set with psi=", psi)
+
+
+if __name__ == "__main__":
+    main()

--- a/a22a/models/team_strength.py
+++ b/a22a/models/team_strength.py
@@ -1,0 +1,41 @@
+"""Bayesian team strength scaffolding."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import polars as pl
+import yaml
+
+CONFIG_PATH = Path(__file__).resolve().parents[2] / "configs" / "team_strength.yaml"
+
+
+def load_config() -> dict:
+    with CONFIG_PATH.open("r", encoding="utf-8") as fh:
+        cfg = yaml.safe_load(fh) or {}
+    return cfg
+
+
+def build_team_strength_table(teams: List[str]) -> pl.DataFrame:
+    cfg = load_config()
+    decay = cfg.get("recency_decay", 0.9)
+    table = pl.DataFrame(
+        {
+            "team_id": teams,
+            "theta": [0.0 for _ in teams],
+            "ci_lower": [-0.1 for _ in teams],
+            "ci_upper": [0.1 for _ in teams],
+            "recency_decay": [decay for _ in teams],
+        }
+    )
+    return table
+
+
+def main() -> None:
+    teams = ["T-000", "T-001"]
+    table = build_team_strength_table(teams)
+    print(table)
+
+
+if __name__ == "__main__":
+    main()

--- a/a22a/models/train_baseline.py
+++ b/a22a/models/train_baseline.py
@@ -1,0 +1,37 @@
+"""Baseline model training scaffolding."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+import polars as pl
+
+
+@dataclass
+class ForwardChainingFold:
+    train_weeks: List[int]
+    validation_weeks: List[int]
+
+
+def forward_chaining_schedule(weeks: Iterable[int]) -> List[ForwardChainingFold]:
+    weeks = sorted(set(weeks))
+    folds: List[ForwardChainingFold] = []
+    for idx in range(1, len(weeks)):
+        folds.append(ForwardChainingFold(train_weeks=weeks[:idx], validation_weeks=[weeks[idx]]))
+    return folds
+
+
+def train_baseline(features: pl.DataFrame) -> None:
+    print(f"[train] received {features.shape[0]} rows and {features.shape[1]} columns")
+
+
+def main() -> None:
+    dummy = pl.DataFrame({"game_id": ["G-000"], "team_id": ["T-000"], "week": [1], "target": [0.0]})
+    folds = forward_chaining_schedule(dummy["week"].to_list())
+    train_baseline(dummy)
+    print(f"[train] generated {len(folds)} forward-chaining folds")
+    print("[train] calibration plot scaffold pending data availability")
+
+
+if __name__ == "__main__":
+    main()

--- a/a22a/reports/weekly.py
+++ b/a22a/reports/weekly.py
@@ -1,0 +1,30 @@
+"""Weekly report scaffolding."""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+REPORTS_DIR = Path("reports")
+
+
+def render_weekly_summary() -> str:
+    timestamp = datetime.utcnow().isoformat()
+    summary = f"Week in review generated at {timestamp}. Awaiting data sources."
+    return summary
+
+
+def write_report(content: str) -> Path:
+    REPORTS_DIR.mkdir(exist_ok=True)
+    path = REPORTS_DIR / "weekly.md"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def main() -> None:
+    content = render_weekly_summary()
+    path = write_report(content)
+    print(f"[report] weekly summary written to {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/a22a/sim/run.py
+++ b/a22a/sim/run.py
@@ -1,0 +1,52 @@
+"""Simulation scaffolding."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable, List
+
+
+@dataclass
+class SimulationConfig:
+    num_draws: int = 16
+    convergence_tol: float = 0.01
+
+
+class EarlyStop(Exception):
+    """Raised when the simulation meets early-stop criteria."""
+
+
+def quasi_monte_carlo_sampler(num_draws: int) -> List[float]:
+    return [idx / num_draws for idx in range(num_draws)]
+
+
+def run_simulation(config: SimulationConfig, hook: Callable[[int, float], bool]) -> List[float]:
+    draws = quasi_monte_carlo_sampler(config.num_draws)
+    results: List[float] = []
+    for idx, draw in enumerate(draws, start=1):
+        results.append(draw)
+        if hook(idx, draw):
+            raise EarlyStop(f"Stopped after {idx} iterations")
+    return results
+
+
+def fair_ladder(results: Iterable[float]) -> List[float]:
+    return sorted(results)
+
+
+def main() -> None:
+    config = SimulationConfig()
+
+    def early_stop_hook(iteration: int, value: float) -> bool:
+        return value >= (1.0 - config.convergence_tol)
+
+    try:
+        results = run_simulation(config, early_stop_hook)
+    except EarlyStop as exc:
+        print(f"[sim] early-stop triggered: {exc}")
+        results = []
+    ladder = fair_ladder(results)
+    print("[sim] ladder placeholder:", ladder)
+
+
+if __name__ == "__main__":
+    main()

--- a/a22a/tools/doctor.py
+++ b/a22a/tools/doctor.py
@@ -1,0 +1,167 @@
+"""Governance doctor for All-22 Atlas."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Mapping
+
+import yaml
+
+REQUIRED_ENV_KEYS = (
+    "OPENAI_API_KEY",
+    "ODDS_API_KEY",
+    "SPORTSGAMEODDS_API_KEY",
+    "WEATHER_API_KEY",
+)
+
+ODDS_DOMAINS = (
+    "theoddsapi.com",
+    "oddsapi.com",
+    "sportsgameodds.com",
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_DIR = REPO_ROOT / "configs"
+FEATURE_DIR = REPO_ROOT / "a22a" / "features"
+PACKAGE_DIR = REPO_ROOT / "a22a"
+
+
+@dataclass
+class SLORecord:
+    """Represents a single SLO budget check."""
+
+    name: str
+    budget_seconds: float
+
+
+class SLOTimer:
+    """Context manager enforcing placeholder SLOs."""
+
+    def __init__(self, record: SLORecord) -> None:
+        self.record = record
+        self._start = 0.0
+
+    def __enter__(self) -> "SLOTimer":
+        self._start = time.perf_counter()
+        print(f"[doctor] starting SLO window for {self.record.name} (budget={self.record.budget_seconds}s)")
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        elapsed = time.perf_counter() - self._start
+        status = "OK" if elapsed <= self.record.budget_seconds else "VIOLATION"
+        print(f"[doctor] completed {self.record.name} in {elapsed:.4f}s -> {status}")
+        if elapsed > self.record.budget_seconds:
+            raise RuntimeError(f"SLO violation for {self.record.name}: {elapsed:.4f}s > {self.record.budget_seconds}s")
+        return False
+
+
+def _load_yaml(path: Path) -> Dict[str, object]:
+    if not path.exists():
+        raise FileNotFoundError(f"Expected config at {path}")
+    with path.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Config {path} must decode to a mapping")
+    return data
+
+
+def compute_seed_hashes(seeds: Mapping[str, str]) -> Dict[str, str]:
+    """Return short SHA256 digests for configured seeds."""
+    hashes: Dict[str, str] = {}
+    for name, value in seeds.items():
+        digest = hashlib.sha256(str(value).encode("utf-8")).hexdigest()
+        hashes[name] = digest[:12]
+    return hashes
+
+
+def validate_env(env: Mapping[str, str] | None = None) -> None:
+    """Ensure required secrets are pulled from the environment."""
+    if env is None:
+        env = os.environ
+    missing = [key for key in REQUIRED_ENV_KEYS if not env.get(key)]
+    if missing:
+        raise EnvironmentError(f"Missing required environment variables: {', '.join(sorted(missing))}")
+
+
+_SECRET_ASSIGNMENT_PATTERNS = [re.compile(rf"{re.escape(key)}\s*=\s*['\"]") for key in REQUIRED_ENV_KEYS]
+
+
+def check_secrets_not_hardcoded(base_path: Path = PACKAGE_DIR) -> None:
+    """Fail if any known secret appears to be hardcoded in Python modules."""
+    for path in base_path.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        for pattern in _SECRET_ASSIGNMENT_PATTERNS:
+            if pattern.search(text):
+                raise RuntimeError(f"Potential hardcoded secret detected in {path}")
+
+
+def scan_feature_code_for_odds(feature_path: Path = FEATURE_DIR) -> None:
+    """Ensure odds provider domains are not referenced in feature engineering code."""
+    for path in feature_path.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        for domain in ODDS_DOMAINS:
+            if domain in text:
+                raise RuntimeError(f"Odds API domain '{domain}' found in {path}")
+
+
+def ensure_run_registry() -> None:
+    registry_path = REPO_ROOT / "staged" / "run_registry.log"
+    if not registry_path.exists():
+        registry_path.touch()
+    print(f"[doctor] run registry available at {registry_path.relative_to(REPO_ROOT)}")
+
+
+def render_report(ci: bool, seed_hashes: Mapping[str, str], slo_config: Mapping[str, object]) -> None:
+    print("[doctor] seed digests:")
+    for name, digest in seed_hashes.items():
+        print(f"    - {name}: {digest}")
+    slo_records = [
+        SLORecord("etl", float(slo_config.get("etl_budget_seconds", 0))),
+        SLORecord("feature_build", float(slo_config.get("feature_budget_seconds", 0))),
+        SLORecord("training", float(slo_config.get("training_budget_seconds", 0))),
+        SLORecord("simulation", float(slo_config.get("simulation_budget_seconds", 0))),
+        SLORecord("reporting", float(slo_config.get("report_budget_seconds", 0))),
+    ]
+    for record in slo_records:
+        with SLOTimer(record):
+            time.sleep(0.001)
+    if ci:
+        print("[doctor] running in CI mode: reduced logging enabled")
+
+
+def run(ci: bool = False) -> None:
+    seeds = _load_yaml(CONFIG_DIR / "seeds.yaml")
+    slo_config = _load_yaml(CONFIG_DIR / "slo.yaml")
+    validate_env()
+    check_secrets_not_hardcoded()
+    scan_feature_code_for_odds()
+    ensure_run_registry()
+    hashes = compute_seed_hashes(seeds)
+    render_report(ci, hashes, slo_config)
+    print("[doctor] all checks passed")
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run All-22 Atlas governance doctor")
+    parser.add_argument("--ci", action="store_true", help="Enable CI mode")
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        run(ci=args.ci)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[doctor] failure: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/configs/seeds.yaml
+++ b/configs/seeds.yaml
@@ -1,0 +1,3 @@
+code_seed: code-placeholder
+data_seed: data-placeholder
+config_seed: config-placeholder

--- a/configs/slo.yaml
+++ b/configs/slo.yaml
@@ -1,0 +1,5 @@
+etl_budget_seconds: 300
+feature_budget_seconds: 120
+training_budget_seconds: 600
+simulation_budget_seconds: 180
+report_budget_seconds: 120

--- a/configs/team_strength.yaml
+++ b/configs/team_strength.yaml
@@ -1,0 +1,2 @@
+recency_decay: 0.85
+prior_scale: 1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "a22a"
+version = "0.1.0"
+description = "All-22 Atlas bootstrap scaffolding"
+authors = [{name = "All-22 Atlas"}]
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "pyyaml>=6.0",
+    "polars>=0.20",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]

--- a/staged/run_registry.log
+++ b/staged/run_registry.log
@@ -1,0 +1,1 @@
+# placeholder run registry

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from a22a.tools import doctor
+
+
+def test_validate_env_missing():
+    with pytest.raises(EnvironmentError):
+        doctor.validate_env(env={})
+
+
+def test_check_secrets_not_hardcoded(tmp_path: Path):
+    module = tmp_path / "module.py"
+    module.write_text("OPENAI_API_KEY = 'abc'", encoding="utf-8")
+    with pytest.raises(RuntimeError):
+        doctor.check_secrets_not_hardcoded(tmp_path)
+
+
+def test_scan_feature_code_for_odds(tmp_path: Path):
+    feature = tmp_path / "feature.py"
+    feature.write_text("# using theoddsapi.com", encoding="utf-8")
+    with pytest.raises(RuntimeError):
+        doctor.scan_feature_code_for_odds(tmp_path)


### PR DESCRIPTION
## Summary
- scaffold governance, configs, and documentation for phases 1–6, including pyproject metadata, env samples, and CI wiring
- implement the doctor tool with seed hashing, SLO timers, secret scanning, and odds-domain guards plus supporting configs
- add ingestion, feature, model, simulation, and reporting stubs with accompanying Make targets and tests

## Testing
- make doctor
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68df16725e4c83329e42443f361f9b1d