### PR TITLE
Implement A22A ingestion through simulation pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 .env
 .venv/
 /data/
+/staged/*.parquet
+/staged/*.json
+/staged/*.csv
+/reports/
+a22a.egg-info/
 __pycache__/
 .DS_Store

--- a/a22a/data/contracts.py
+++ b/a22a/data/contracts.py
@@ -1,51 +1,257 @@
-"""Data contracts for staged inputs."""
+"""Data contracts for staged inputs.
+
+The Phase 1–2 ingest stack produces a family of staged Parquet artefacts that
+mirror a trimmed-down nflverse schema. This module provides reusable contracts
+that guard schema drift both for the in-memory records used during tests as
+well as the Polars frames that back the persisted parquet files.
+"""
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Iterable, Mapping, Sequence
 
+import polars as pl
+
+__all__ = [
+    "JOIN_KEYS",
+    "STAGED_GAME_SCHEMA",
+    "DatasetContract",
+    "ContractViolation",
+    "validate_records",
+    "validate_frame",
+]
+
+
+@dataclass(frozen=True)
+class Field:
+    """Represents a required column in the staged schema."""
+
+    name: str
+    dtype: pl.DataType
+    optional: bool = False
+
+    def validate(self, frame: pl.DataFrame, dataset: str) -> None:
+        if self.name not in frame.columns:
+            raise ContractViolation(
+                dataset=dataset,
+                message=f"Missing required column '{self.name}'",
+                record_index=-1,
+            )
+        series = frame.get_column(self.name)
+        if series.null_count() > 0 and not self.optional:
+            raise ContractViolation(
+                dataset=dataset,
+                message=f"Column '{self.name}' contains null values",
+                record_index=-1,
+            )
+        if series.dtype != self.dtype:
+            try:
+                series.cast(self.dtype)
+            except Exception as exc:  # noqa: BLE001
+                raise ContractViolation(
+                    dataset=dataset,
+                    message=(
+                        f"Column '{self.name}' expected dtype {self.dtype}, "
+                        f"received {series.dtype}"
+                    ),
+                    record_index=-1,
+                ) from exc
+
+
+@dataclass(frozen=True)
+class DatasetContract:
+    """Contract definition for a staged dataset."""
+
+    name: str
+    fields: Sequence[Field]
+    primary_key: Sequence[str]
+
+    def validate_frame(self, frame: pl.DataFrame) -> pl.DataFrame:
+        if frame.is_empty():
+            return frame
+        for field in self.fields:
+            field.validate(frame, dataset=self.name)
+        missing_keys = set(self.primary_key) - set(frame.columns)
+        if missing_keys:
+            raise ContractViolation(
+                dataset=self.name,
+                message=f"Missing primary key columns: {sorted(missing_keys)}",
+                record_index=-1,
+            )
+        key_counts = frame.group_by(list(self.primary_key)).len()
+        duplicated_keys = key_counts.filter(pl.col("len") > 1)
+        if duplicated_keys.height > 0:
+            duplicated_key = duplicated_keys.row(0)
+            mask = pl.all_horizontal(
+                [pl.col(column) == value for column, value in zip(self.primary_key, duplicated_key)]
+            )
+            index = (
+                frame
+                .with_row_count()
+                .filter(mask)
+                .select("row_nr")
+                .to_series()
+                .to_list()[0]
+            )
+            raise ContractViolation(
+                dataset=self.name,
+                message="Primary key uniqueness violated",
+                record_index=int(index),
+            )
+        return frame
+
+
+@dataclass
+class ContractViolation(Exception):
+    """Raised when staged data fails to meet the expected schema."""
+
+    dataset: str
+    message: str
+    record_index: int
+
+    def __str__(self) -> str:  # pragma: no cover - repr convenience
+        return f"{self.dataset}: {self.message} (record={self.record_index})"
+
+
 STAGED_GAME_SCHEMA = {
-    "game_id": str,
-    "season": int,
-    "week": int,
-    "team_id": str,
-    "opponent_id": str,
+    "game_id": pl.Utf8,
+    "season": pl.Int64,
+    "week": pl.Int64,
+    "team_id": pl.Utf8,
+    "opponent_id": pl.Utf8,
 }
 
 JOIN_KEYS = {"game_id", "team_id"}
 
 
-@dataclass
-class ContractViolation(Exception):
-    message: str
-    record_index: int
+CONTRACTS: Mapping[str, DatasetContract] = {
+    "pbp": DatasetContract(
+        name="pbp",
+        primary_key=("game_id", "play_id"),
+        fields=(
+            Field("game_id", pl.Utf8),
+            Field("play_id", pl.Int64),
+            Field("drive_id", pl.Utf8),
+            Field("season", pl.Int64),
+            Field("week", pl.Int64),
+            Field("posteam", pl.Utf8),
+            Field("defteam", pl.Utf8),
+            Field("yards_gained", pl.Float64),
+            Field("scoring_margin", pl.Float64),
+            Field("success", pl.Boolean),
+        ),
+    ),
+    "drives": DatasetContract(
+        name="drives",
+        primary_key=("game_id", "drive_id"),
+        fields=(
+            Field("game_id", pl.Utf8),
+            Field("drive_id", pl.Utf8),
+            Field("season", pl.Int64),
+            Field("week", pl.Int64),
+            Field("team_id", pl.Utf8),
+            Field("result", pl.Utf8),
+            Field("plays", pl.Int64),
+            Field("yards", pl.Float64),
+            Field("points", pl.Float64),
+        ),
+    ),
+    "schedule": DatasetContract(
+        name="schedule",
+        primary_key=("game_id",),
+        fields=(
+            Field("game_id", pl.Utf8),
+            Field("season", pl.Int64),
+            Field("week", pl.Int64),
+            Field("home_team", pl.Utf8),
+            Field("away_team", pl.Utf8),
+            Field("home_points", pl.Int64),
+            Field("away_points", pl.Int64),
+            Field("game_datetime", pl.Datetime("ns")),
+            Field("venue", pl.Utf8),
+        ),
+    ),
+    "roster": DatasetContract(
+        name="roster",
+        primary_key=("season", "team_id", "player_id"),
+        fields=(
+            Field("season", pl.Int64),
+            Field("team_id", pl.Utf8),
+            Field("player_id", pl.Utf8),
+            Field("position", pl.Utf8),
+            Field("full_name", pl.Utf8),
+            Field("experience", pl.Int64, optional=True),
+        ),
+    ),
+    "team_games": DatasetContract(
+        name="team_games",
+        primary_key=("game_id", "team_id"),
+        fields=(
+            Field("game_id", pl.Utf8),
+            Field("season", pl.Int64),
+            Field("week", pl.Int64),
+            Field("team_id", pl.Utf8),
+            Field("opponent_id", pl.Utf8),
+            Field("is_home", pl.Boolean),
+            Field("points_for", pl.Int64),
+            Field("points_against", pl.Int64),
+            Field("margin", pl.Int64),
+            Field("total_points", pl.Int64),
+            Field("win", pl.Int64),
+            Field("game_datetime", pl.Datetime("ns")),
+        ),
+    ),
+    "team_strength": DatasetContract(
+        name="team_strength",
+        primary_key=("season", "week", "team_id"),
+        fields=(
+            Field("season", pl.Int64),
+            Field("week", pl.Int64),
+            Field("team_id", pl.Utf8),
+            Field("theta_mean", pl.Float64),
+            Field("theta_ci_lower", pl.Float64),
+            Field("theta_ci_upper", pl.Float64),
+            Field("samples", pl.Float64),
+        ),
+    ),
+}
 
 
-def assert_schema(records: Sequence[Mapping[str, object]]) -> None:
-    for idx, record in enumerate(records):
-        missing = STAGED_GAME_SCHEMA.keys() - record.keys()
-        if missing:
-            raise ContractViolation(f"Missing fields: {sorted(missing)}", idx)
-        for column, expected_type in STAGED_GAME_SCHEMA.items():
-            value = record[column]
-            if value is None:
-                raise ContractViolation(f"Column '{column}' cannot be None", idx)
-            if not isinstance(value, expected_type):
-                raise ContractViolation(
-                    f"Column '{column}' expected {expected_type.__name__}, got {type(value).__name__}",
-                    idx,
-                )
-        if not JOIN_KEYS.issubset(record.keys()):
-            raise ContractViolation("Missing join keys", idx)
+def _contract(dataset: str) -> DatasetContract:
+    try:
+        return CONTRACTS[dataset]
+    except KeyError as exc:  # pragma: no cover - defensive programming
+        raise KeyError(f"Unknown dataset '{dataset}'") from exc
 
 
-def validate_records(records: Iterable[Mapping[str, object]]) -> bool:
-    """Validate staged records against the contract schema."""
+def _ensure_frame(records: Iterable[Mapping[str, object]]) -> pl.DataFrame:
+    return pl.DataFrame(list(records))
+
+
+def validate_records(records: Iterable[Mapping[str, object]], dataset: str = "team_games") -> bool:
+    """Validate staged records against a named contract.
+
+    Parameters
+    ----------
+    records:
+        Iterable of mapping-like records.
+    dataset:
+        Name of the dataset contract to evaluate.
+    """
+
     records = list(records)
     if not records:
         return True
-    assert_schema(records)
+    frame = _ensure_frame(records)
+    validate_frame(frame, dataset)
     return True
+
+
+def validate_frame(frame: pl.DataFrame, dataset: str) -> pl.DataFrame:
+    """Validate a Polars frame against a dataset contract."""
+
+    contract = _contract(dataset)
+    return contract.validate_frame(frame)
 
 
 def main() -> None:

--- a/a22a/data/ingest.py
+++ b/a22a/data/ingest.py
@@ -1,10 +1,13 @@
-"""ETL ingest scaffolding."""
+"""Synthetic ETL ingest for the Atlas Phase 1–2 deliverables."""
 from __future__ import annotations
 
+from datetime import datetime
 from pathlib import Path
-from typing import Iterable, Mapping
+from typing import Dict
 
-from .contracts import JOIN_KEYS, STAGED_GAME_SCHEMA, validate_records
+import polars as pl
+
+from .contracts import CONTRACTS, JOIN_KEYS, STAGED_GAME_SCHEMA, validate_frame
 
 STAGED_DIR = Path("staged")
 
@@ -14,23 +17,196 @@ def ensure_staged_dir() -> Path:
     return STAGED_DIR
 
 
-def load_raw_sources() -> Iterable[Mapping[str, object]]:
-    """Placeholder for upstream extraction."""
-    return []
+def _build_schedule(season: int) -> pl.DataFrame:
+    games = [
+        {
+            "game_id": "2023WK01-BUF-KC",
+            "season": season,
+            "week": 1,
+            "home_team": "KC",
+            "away_team": "BUF",
+            "home_points": 27,
+            "away_points": 24,
+            "game_datetime": datetime(2023, 9, 7, 20, 20),
+            "venue": "GEHA Field",
+        },
+        {
+            "game_id": "2023WK01-PHI-DAL",
+            "season": season,
+            "week": 1,
+            "home_team": "DAL",
+            "away_team": "PHI",
+            "home_points": 21,
+            "away_points": 17,
+            "game_datetime": datetime(2023, 9, 10, 16, 25),
+            "venue": "AT&T Stadium",
+        },
+        {
+            "game_id": "2023WK02-KC-PHI",
+            "season": season,
+            "week": 2,
+            "home_team": "PHI",
+            "away_team": "KC",
+            "home_points": 23,
+            "away_points": 26,
+            "game_datetime": datetime(2023, 9, 17, 13, 0),
+            "venue": "Lincoln Financial Field",
+        },
+        {
+            "game_id": "2023WK02-BUF-DAL",
+            "season": season,
+            "week": 2,
+            "home_team": "BUF",
+            "away_team": "DAL",
+            "home_points": 31,
+            "away_points": 20,
+            "game_datetime": datetime(2023, 9, 17, 16, 5),
+            "venue": "Highmark Stadium",
+        },
+    ]
+    return pl.DataFrame(games)
 
 
-def apply_contract(records: Iterable[Mapping[str, object]]) -> bool:
-    return validate_records(records)
+def _build_roster(season: int) -> pl.DataFrame:
+    players = [
+        {"season": season, "team_id": team, "player_id": f"{team}-{idx:02d}", "position": pos, "full_name": name, "experience": exp}
+        for team, roster in {
+            "BUF": [("QB", "Josh Allen", 6), ("WR", "Stefon Diggs", 8)],
+            "KC": [("QB", "Patrick Mahomes", 6), ("TE", "Travis Kelce", 10)],
+            "PHI": [("QB", "Jalen Hurts", 4), ("WR", "A.J. Brown", 5)],
+            "DAL": [("QB", "Dak Prescott", 8), ("WR", "CeeDee Lamb", 4)],
+        }.items()
+        for idx, (pos, name, exp) in enumerate(roster, start=1)
+    ]
+    return pl.DataFrame(players)
+
+
+def _build_drives_and_pbp(schedule: pl.DataFrame) -> Dict[str, pl.DataFrame]:
+    pbp_rows = []
+    drive_rows = []
+    play_id = 1
+    for game in schedule.iter_rows(named=True):
+        for team_id, opponent_id, is_home in (
+            (game["home_team"], game["away_team"], True),
+            (game["away_team"], game["home_team"], False),
+        ):
+            for drive_idx in range(1, 4):
+                drive_id = f"{team_id}-D{drive_idx}"
+                yards = 25 + 10 * drive_idx + (3 if is_home else 0)
+                points = 7.0 if drive_idx % 2 == 0 else 3.0
+                result = "TD" if points >= 7 else "FG"
+                drive_rows.append(
+                    {
+                        "game_id": game["game_id"],
+                        "drive_id": drive_id,
+                        "season": game["season"],
+                        "week": game["week"],
+                        "team_id": team_id,
+                        "result": result,
+                        "plays": 6 + drive_idx,
+                        "yards": float(yards),
+                        "points": points,
+                    }
+                )
+                for play_offset in range(1, 4):
+                    yards_gained = float(4 * play_offset + (2 if result == "TD" else 0))
+                    scoring_margin = (points if result == "TD" else points - 3) + (drive_idx - 2)
+                    pbp_rows.append(
+                        {
+                            "game_id": game["game_id"],
+                            "play_id": play_id,
+                            "drive_id": drive_id,
+                            "season": game["season"],
+                            "week": game["week"],
+                            "posteam": team_id,
+                            "defteam": opponent_id,
+                            "yards_gained": yards_gained,
+                            "scoring_margin": float(scoring_margin),
+                            "success": yards_gained >= 4.0,
+                        }
+                    )
+                    play_id += 1
+    pbp = pl.DataFrame(pbp_rows)
+    drives = pl.DataFrame(drive_rows)
+    return {"pbp": pbp, "drives": drives}
+
+
+def _build_team_games(schedule: pl.DataFrame) -> pl.DataFrame:
+    home = schedule.select(
+        [
+            pl.col("game_id"),
+            pl.col("season"),
+            pl.col("week"),
+            pl.col("home_team").alias("team_id"),
+            pl.col("away_team").alias("opponent_id"),
+            pl.lit(True).alias("is_home"),
+            pl.col("home_points").alias("points_for"),
+            pl.col("away_points").alias("points_against"),
+            pl.col("game_datetime"),
+        ]
+    )
+    away = schedule.select(
+        [
+            pl.col("game_id"),
+            pl.col("season"),
+            pl.col("week"),
+            pl.col("away_team").alias("team_id"),
+            pl.col("home_team").alias("opponent_id"),
+            pl.lit(False).alias("is_home"),
+            pl.col("away_points").alias("points_for"),
+            pl.col("home_points").alias("points_against"),
+            pl.col("game_datetime"),
+        ]
+    )
+    team_games = pl.concat([home, away]).with_columns(
+        (pl.col("points_for") - pl.col("points_against")).alias("margin"),
+        (pl.col("points_for") + pl.col("points_against")).alias("total_points"),
+        pl.when(pl.col("points_for") > pl.col("points_against")).then(1).otherwise(0).alias("win"),
+    )
+    return team_games.sort(["season", "week", "game_id", "team_id"])
+
+
+def load_raw_sources() -> Dict[str, pl.DataFrame]:
+    """Produce deterministic sample datasets that satisfy the data contracts."""
+
+    season = 2023
+    schedule = _build_schedule(season)
+    roster = _build_roster(season)
+    staged = _build_drives_and_pbp(schedule)
+    staged["schedule"] = schedule
+    staged["roster"] = roster
+    staged["team_games"] = _build_team_games(schedule)
+    return staged
+
+
+def apply_contract(frames: Dict[str, pl.DataFrame]) -> None:
+    for name, frame in frames.items():
+        dataset_name = name if name in CONTRACTS else "team_games"
+        validate_frame(frame, dataset_name)
+
+
+def _stage_frame(name: str, frame: pl.DataFrame) -> Path:
+    path = STAGED_DIR / f"{name}.parquet"
+    frame.write_parquet(path)
+    return path
 
 
 def main() -> None:
     ensure_staged_dir()
-    records = list(load_raw_sources())
-    if not records:
-        print("[ingest] no upstream data detected; ETL noop")
-    else:
-        apply_contract(records)
-        print(f"[ingest] staged {len(records)} records with schema {list(STAGED_GAME_SCHEMA)} and joins {JOIN_KEYS}")
+    frames = load_raw_sources()
+    apply_contract(frames)
+    materialised = {name: _stage_frame(name, frame) for name, frame in frames.items()}
+    summary = ", ".join(f"{name}={frame.height}" for name, frame in frames.items())
+    print(
+        "[ingest] staged datasets with schema keys",
+        sorted(STAGED_GAME_SCHEMA),
+        "join keys",
+        sorted(JOIN_KEYS),
+        f"records -> {summary}",
+    )
+    print("[ingest] materialised:")
+    for name, path in materialised.items():
+        print(f"    - {name}: {path}")
 
 
 if __name__ == "__main__":

--- a/a22a/features/build.py
+++ b/a22a/features/build.py
@@ -1,53 +1,181 @@
-"""Feature store scaffolding with leakage guard and PSI hook."""
+"""Feature engineering pipeline for phases 3–5."""
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
+from typing import Dict, List
 
+import numpy as np
 import polars as pl
 
+from a22a.models import team_strength as team_strength_module
+
 STAGED_DIR = Path("staged")
-FEATURE_OUTPUT = Path("data") / "features.parquet"
+FEATURE_DIR = Path("data") / "features"
+REFERENCE_PATH = FEATURE_DIR / "reference.parquet"
 
 
-def leakage_guard(features: pl.LazyFrame) -> None:
-    required = {"game_id", "team_id"}
-    if not required.issubset(set(features.columns)):
-        missing = required - set(features.columns)
-        raise ValueError(f"Leakage guard failed: missing {missing}")
+def _ensure_team_strength() -> Path:
+    output = STAGED_DIR / "team_strength.parquet"
+    if not output.exists():
+        team_strength_module.main()
+    return output
 
 
-def compute_psi(reference: pl.DataFrame, current: pl.DataFrame) -> Optional[float]:
+def _scan_staged(name: str) -> pl.LazyFrame:
+    path = STAGED_DIR / f"{name}.parquet"
+    if not path.exists():
+        raise FileNotFoundError(f"Expected staged dataset {path}; run `make ingest`." )
+    return pl.scan_parquet(path)
+
+
+def leakage_guard(features: pl.DataFrame) -> None:
+    required = {"game_id", "team_id", "season", "week", "target"}
+    missing = required - set(features.columns)
+    if missing:
+        raise ValueError(f"Leakage guard failed: missing {sorted(missing)}")
+    duplicates = features.group_by(["game_id", "team_id"]).len().filter(pl.col("len") > 1)
+    if duplicates.height > 0:
+        raise ValueError("Leakage guard failed: duplicate game/team rows detected")
+    if (features["week"] <= 0).any():
+        raise ValueError("Leakage guard failed: invalid week values detected")
+
+
+def _psi(reference: np.ndarray, current: np.ndarray, bins: int = 10) -> float:
+    hist_ref, edges = np.histogram(reference, bins=bins)
+    hist_cur, _ = np.histogram(current, bins=edges)
+    ref_pct = np.maximum(hist_ref / hist_ref.sum(), 1e-6)
+    cur_pct = np.maximum(hist_cur / hist_cur.sum(), 1e-6)
+    return float(np.sum((cur_pct - ref_pct) * np.log(cur_pct / ref_pct)))
+
+
+def compute_psi(reference: pl.DataFrame, current: pl.DataFrame) -> Dict[str, float]:
     if reference.is_empty() or current.is_empty():
-        return None
-    return 0.0
+        return {}
+    numeric_columns = [
+        column
+        for column, dtype in current.schema.items()
+        if dtype.is_numeric() and column not in {"season", "week", "target"}
+    ]
+    scores: Dict[str, float] = {}
+    for column in numeric_columns:
+        scores[column] = _psi(reference[column].to_numpy(), current[column].to_numpy())
+    return scores
 
 
 def build_feature_view() -> pl.LazyFrame:
-    base = pl.DataFrame(
-        {
-            "game_id": ["G-000"],
-            "team_id": ["T-000"],
-            "dummy_metric": [0.0],
-        }
-    ).lazy()
-    return base
+    _ensure_team_strength()
+
+    team_games = _scan_staged("team_games")
+    pbp = _scan_staged("pbp")
+    drives = _scan_staged("drives")
+    team_strength = _scan_staged("team_strength")
+
+    pbp_features = (
+        pbp.with_columns(pl.col("posteam").alias("team_id"))
+        .group_by(["season", "week", "game_id", "team_id"])
+        .agg(
+            pl.len().alias("plays"),
+            pl.col("yards_gained").mean().alias("avg_yards_gained"),
+            pl.col("yards_gained").max().alias("max_yards_gained"),
+            pl.col("success").mean().alias("success_rate"),
+            pl.col("scoring_margin").mean().alias("avg_scoring_margin_post"),
+        )
+    )
+
+    drive_features = (
+        drives.group_by(["season", "week", "game_id", "team_id"])
+        .agg(
+            pl.sum("points").alias("drive_points"),
+            pl.mean("points").alias("avg_drive_points"),
+            pl.sum("yards").alias("drive_yards"),
+            (pl.sum("points") / pl.sum("plays")).alias("points_per_play"),
+        )
+        .with_columns(
+            pl.col("drive_points").fill_null(0.0),
+            pl.col("avg_drive_points").fill_null(0.0),
+            pl.col("drive_yards").fill_null(0.0),
+            pl.col("points_per_play").fill_null(0.0),
+        )
+    )
+
+    lagged_team = (
+        team_games.with_columns(
+            pl.col("margin").shift(1).over("team_id").alias("lag_margin"),
+            pl.col("win").shift(1).over("team_id").alias("lag_win"),
+            pl.col("points_for").shift(1).over("team_id").alias("lag_points_for"),
+            pl.col("points_against").shift(1).over("team_id").alias("lag_points_against"),
+        )
+        .with_columns(
+            pl.col("lag_margin").fill_null(0.0),
+            pl.col("lag_win").fill_null(0.0),
+            pl.col("lag_points_for").fill_null(0.0),
+            pl.col("lag_points_against").fill_null(0.0),
+            pl.col("lag_margin").rolling_mean(window_size=3).over("team_id").fill_null(0.0).alias("rolling_margin_3"),
+        )
+    )
+
+    features = (
+        lagged_team
+        .join(pbp_features, on=["season", "week", "game_id", "team_id"], how="left")
+        .join(drive_features, on=["season", "week", "game_id", "team_id"], how="left")
+        .join(team_strength, on=["season", "week", "team_id"], how="left")
+    )
+
+    opponent_strength = team_strength.rename({
+        "team_id": "opponent_id",
+        "theta_mean": "opponent_theta_mean",
+        "theta_ci_lower": "opponent_theta_ci_lower",
+        "theta_ci_upper": "opponent_theta_ci_upper",
+        "samples": "opponent_strength_samples",
+    })
+
+    features = (
+        features.join(opponent_strength, on=["season", "week", "opponent_id"], how="left")
+        .with_columns(
+            pl.col("theta_mean").fill_null(0.0),
+            pl.col("opponent_theta_mean").fill_null(0.0),
+            (pl.col("theta_mean") - pl.col("opponent_theta_mean")).alias("theta_diff"),
+            pl.col("win").cast(pl.Float64).alias("target"),
+        )
+    )
+
+    return features
 
 
-def materialize(features: pl.LazyFrame) -> None:
-    FEATURE_OUTPUT.parent.mkdir(exist_ok=True)
-    features.collect().write_parquet(FEATURE_OUTPUT)
+def _materialize_weekly(features: pl.DataFrame) -> List[Path]:
+    FEATURE_DIR.mkdir(parents=True, exist_ok=True)
+    written: List[Path] = []
+    for (season, week), frame in features.group_by(["season", "week"], maintain_order=True):
+        season_dir = FEATURE_DIR / f"season={season}"
+        season_dir.mkdir(parents=True, exist_ok=True)
+        path = season_dir / f"week={int(week):02d}.parquet"
+        frame.write_parquet(path)
+        written.append(path)
+    return written
+
+
+def materialize(features: pl.LazyFrame) -> Dict[str, object]:
+    current = features.collect()
+    leakage_guard(current)
+    psi_scores: Dict[str, float]
+    if REFERENCE_PATH.exists():
+        reference = pl.read_parquet(REFERENCE_PATH)
+        psi_scores = compute_psi(reference, current)
+    else:
+        psi_scores = {}
+    FEATURE_DIR.mkdir(parents=True, exist_ok=True)
+    current.write_parquet(REFERENCE_PATH)
+    paths = _materialize_weekly(current)
+    return {"paths": paths, "psi": psi_scores, "rows": current.height}
 
 
 def main() -> None:
     STAGED_DIR.mkdir(exist_ok=True)
     features = build_feature_view()
-    leakage_guard(features)
-    reference = pl.DataFrame()
-    current = features.collect()
-    psi = compute_psi(reference, current)
-    materialize(features)
-    print("[features] built lazy feature set with psi=", psi)
+    artefacts = materialize(features)
+    psi_summary = ", ".join(f"{k}={v:.4f}" for k, v in sorted(artefacts["psi"].items())) or "n/a"
+    print(f"[features] materialised {artefacts['rows']} rows -> {len(artefacts['paths'])} weekly files")
+    print(f"[features] psi drift summary: {psi_summary}")
 
 
 if __name__ == "__main__":

--- a/a22a/models/team_strength.py
+++ b/a22a/models/team_strength.py
@@ -1,40 +1,93 @@
-"""Bayesian team strength scaffolding."""
+"""Bayesian-style team strength estimates with recency decay."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
-from typing import List
+from typing import Dict, Iterable, Mapping
 
 import polars as pl
 import yaml
 
+from a22a.data.contracts import validate_frame
+
 CONFIG_PATH = Path(__file__).resolve().parents[2] / "configs" / "team_strength.yaml"
+STAGED_DIR = Path(__file__).resolve().parents[2] / "staged"
 
 
-def load_config() -> dict:
+@dataclass
+class TeamState:
+    mean: float = 0.0
+    samples: float = 1.0
+
+    def decay(self, factor: float) -> None:
+        self.mean *= factor
+        self.samples = max(self.samples * factor, 1.0)
+
+    def update(self, observation: float) -> None:
+        weight = self.samples
+        self.samples += 1.0
+        self.mean = (self.mean * weight + observation) / self.samples
+
+
+def load_config() -> Dict[str, float]:
     with CONFIG_PATH.open("r", encoding="utf-8") as fh:
         cfg = yaml.safe_load(fh) or {}
     return cfg
 
 
-def build_team_strength_table(teams: List[str]) -> pl.DataFrame:
+def _prepare_states(teams: Iterable[str]) -> Dict[str, TeamState]:
+    return {team: TeamState() for team in teams}
+
+
+def _scaled_margin(row: Mapping[str, object]) -> float:
+    margin = float(row["margin"])
+    total = max(float(row["total_points"]), 1.0)
+    return margin / total * 10.0
+
+
+def compute_team_strength(team_games: pl.DataFrame) -> pl.DataFrame:
     cfg = load_config()
-    decay = cfg.get("recency_decay", 0.9)
-    table = pl.DataFrame(
-        {
-            "team_id": teams,
-            "theta": [0.0 for _ in teams],
-            "ci_lower": [-0.1 for _ in teams],
-            "ci_upper": [0.1 for _ in teams],
-            "recency_decay": [decay for _ in teams],
-        }
-    )
-    return table
+    decay = float(cfg.get("recency_decay", 0.85))
+    prior_scale = float(cfg.get("prior_scale", 1.0))
+
+    team_games = team_games.sort(["season", "week", "game_datetime", "team_id"])
+    teams = team_games.get_column("team_id").unique().to_list()
+    states = _prepare_states(teams)
+
+    records = []
+    for row in team_games.iter_rows(named=True):
+        state = states[row["team_id"]]
+        state.decay(decay)
+        std = prior_scale / (state.samples**0.5)
+        records.append(
+            {
+                "season": row["season"],
+                "week": row["week"],
+                "team_id": row["team_id"],
+                "theta_mean": state.mean,
+                "theta_ci_lower": state.mean - 1.96 * std,
+                "theta_ci_upper": state.mean + 1.96 * std,
+                "samples": state.samples,
+            }
+        )
+        observation = _scaled_margin(row)
+        state.update(observation)
+
+    frame = pl.DataFrame(records)
+    if not frame.is_empty():
+        validate_frame(frame, "team_strength")
+    return frame
 
 
 def main() -> None:
-    teams = ["T-000", "T-001"]
-    table = build_team_strength_table(teams)
-    print(table)
+    team_games_path = STAGED_DIR / "team_games.parquet"
+    if not team_games_path.exists():
+        raise FileNotFoundError(f"Expected {team_games_path} – run `make ingest` first")
+    team_games = pl.read_parquet(team_games_path)
+    strength = compute_team_strength(team_games)
+    output = STAGED_DIR / "team_strength.parquet"
+    strength.write_parquet(output)
+    print(f"[team-strength] computed {strength.height} rows -> {output}")
 
 
 if __name__ == "__main__":

--- a/a22a/models/train_baseline.py
+++ b/a22a/models/train_baseline.py
@@ -1,10 +1,24 @@
-"""Baseline model training scaffolding."""
+"""LightGBM baseline with purged forward chaining and calibration."""
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, List
+from pathlib import Path
+from typing import Dict, Iterable, List
 
+import lightgbm as lgb
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
 import polars as pl
+from sklearn.calibration import calibration_curve
+from sklearn.isotonic import IsotonicRegression
+from sklearn.linear_model import LogisticRegression
+
+FEATURE_DIR = Path("data") / "features"
+MODEL_DIR = Path("data") / "model"
+REPORT_DIR = Path("reports")
+PREDICTION_PATH = MODEL_DIR / "win_probabilities.parquet"
+RELIABILITY_PATH = REPORT_DIR / "reliability.png"
 
 
 @dataclass
@@ -13,24 +27,170 @@ class ForwardChainingFold:
     validation_weeks: List[int]
 
 
-def forward_chaining_schedule(weeks: Iterable[int]) -> List[ForwardChainingFold]:
-    weeks = sorted(set(weeks))
+def forward_chaining_schedule(weeks: Iterable[int], purge_gap: int = 1) -> List[ForwardChainingFold]:
+    ordered = sorted(set(int(week) for week in weeks))
     folds: List[ForwardChainingFold] = []
-    for idx in range(1, len(weeks)):
-        folds.append(ForwardChainingFold(train_weeks=weeks[:idx], validation_weeks=[weeks[idx]]))
+    for idx, validation_week in enumerate(ordered[1:], start=1):
+        train_cutoff = validation_week - purge_gap
+        train_weeks = [week for week in ordered[:idx] if week <= train_cutoff]
+        if not train_weeks:
+            continue
+        folds.append(ForwardChainingFold(train_weeks=train_weeks, validation_weeks=[validation_week]))
     return folds
 
 
-def train_baseline(features: pl.DataFrame) -> None:
-    print(f"[train] received {features.shape[0]} rows and {features.shape[1]} columns")
+def _load_feature_table() -> pl.DataFrame:
+    if not FEATURE_DIR.exists():
+        raise FileNotFoundError("Feature directory missing – run `make features` first")
+    frames: List[pl.DataFrame] = []
+    for path in sorted(FEATURE_DIR.rglob("*.parquet")):
+        frames.append(pl.read_parquet(path))
+    if not frames:
+        raise FileNotFoundError("No feature parquet files found")
+    return pl.concat(frames, how="vertical")
+
+
+def _encode_categoricals(frame: pd.DataFrame, categorical_columns: Iterable[str]) -> pd.DataFrame:
+    encoded = frame.copy()
+    for column in categorical_columns:
+        encoded[column] = encoded[column].astype("category").cat.codes
+    return encoded
+
+
+def _prepare_design_matrix(features: pl.DataFrame) -> tuple[pd.DataFrame, pd.Series, List[str]]:
+    df = features.to_pandas()
+    categorical_columns = ["team_id", "opponent_id"]
+    df = _encode_categoricals(df, categorical_columns)
+    drop_columns = {"game_id", "game_datetime", "target"}
+    feature_columns = [column for column in df.columns if column not in drop_columns]
+    X = df[feature_columns]
+    y = df["target"].astype(float)
+    return X, y, feature_columns
+
+
+def _calibrate_probabilities(probs: np.ndarray, y_true: np.ndarray) -> tuple[np.ndarray, str]:
+    unique_labels = np.unique(y_true)
+    if unique_labels.shape[0] < 2:
+        return probs, "identity"
+    if len(y_true) < 10:
+        calibrator = LogisticRegression(max_iter=1000)
+        calibrator.fit(probs.reshape(-1, 1), y_true)
+        calibrated = calibrator.predict_proba(probs.reshape(-1, 1))[:, 1]
+        return calibrated, "platt"
+    calibrator = IsotonicRegression(out_of_bounds="clip")
+    calibrator.fit(probs, y_true)
+    calibrated = calibrator.transform(probs)
+    return calibrated, "isotonic"
+
+
+def _plot_reliability(y_true: np.ndarray, probs: np.ndarray) -> None:
+    REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    prob_true, prob_pred = calibration_curve(y_true, probs, n_bins=5, strategy="uniform")
+    plt.figure(figsize=(5, 5))
+    plt.plot(prob_pred, prob_true, marker="o", label="Baseline")
+    plt.plot([0, 1], [0, 1], linestyle="--", color="gray", label="Perfect calibration")
+    plt.xlabel("Predicted win probability")
+    plt.ylabel("Empirical win rate")
+    plt.title("Win probability reliability")
+    plt.legend()
+    plt.grid(alpha=0.3)
+    plt.tight_layout()
+    plt.savefig(RELIABILITY_PATH, dpi=200)
+    plt.close()
+
+
+def train_baseline(features: pl.DataFrame) -> Dict[str, object]:
+    X, y, feature_columns = _prepare_design_matrix(features)
+    weeks = features["week"].to_list()
+    folds = forward_chaining_schedule(weeks)
+
+    MODEL_DIR.mkdir(parents=True, exist_ok=True)
+
+    oof_records: List[pd.DataFrame] = []
+    models: List[lgb.LGBMClassifier] = []
+
+    for fold_index, fold in enumerate(folds):
+        train_mask = X["week"].isin(fold.train_weeks)
+        val_mask = X["week"].isin(fold.validation_weeks)
+        if train_mask.sum() == 0 or val_mask.sum() == 0:
+            continue
+        model = lgb.LGBMClassifier(
+            objective="binary",
+            n_estimators=200,
+            learning_rate=0.05,
+            subsample=0.8,
+            colsample_bytree=0.8,
+            random_state=42,
+        )
+        model.fit(X[train_mask], y[train_mask])
+        val_probs = model.predict_proba(X[val_mask])[:, 1]
+        fold_df = pd.DataFrame(
+            {
+                "game_id": features.filter(pl.col("week").is_in(fold.validation_weeks))["game_id"].to_list(),
+                "team_id": features.filter(pl.col("week").is_in(fold.validation_weeks))["team_id"].to_list(),
+                "week": X.loc[val_mask, "week"].to_list(),
+                "season": X.loc[val_mask, "season"].to_list(),
+                "win_prob_raw": val_probs,
+                "target": y[val_mask].to_numpy(),
+                "fold": fold_index,
+            }
+        )
+        oof_records.append(fold_df)
+        models.append(model)
+
+    if not oof_records:
+        raise RuntimeError("Not enough data to perform forward-chaining CV")
+
+    oof_df = pd.concat(oof_records, ignore_index=True)
+    calibrated_probs, calibration_method = _calibrate_probabilities(
+        oof_df["win_prob_raw"].to_numpy(), oof_df["target"].to_numpy()
+    )
+    oof_df["win_prob_calibrated"] = calibrated_probs
+    _plot_reliability(oof_df["target"].to_numpy(), calibrated_probs)
+
+    final_model = lgb.LGBMClassifier(
+        objective="binary",
+        n_estimators=300,
+        learning_rate=0.05,
+        subsample=0.9,
+        colsample_bytree=0.9,
+        random_state=21,
+    )
+    final_model.fit(X, y)
+    final_probs = final_model.predict_proba(X)[:, 1]
+    final_calibrated, _ = _calibrate_probabilities(final_probs, y.to_numpy())
+
+    prediction_table = pd.DataFrame(
+        {
+            "game_id": features["game_id"].to_list(),
+            "team_id": features["team_id"].to_list(),
+            "season": features["season"].to_list(),
+            "week": features["week"].to_list(),
+            "win_prob_raw": final_probs,
+            "win_prob_calibrated": final_calibrated,
+        }
+    )
+    pl.from_pandas(prediction_table).write_parquet(PREDICTION_PATH)
+
+    summary = {
+        "folds": len(oof_records),
+        "calibration_method": calibration_method,
+        "features": feature_columns,
+        "predictions_path": PREDICTION_PATH,
+        "reliability_plot": RELIABILITY_PATH,
+    }
+    return summary
 
 
 def main() -> None:
-    dummy = pl.DataFrame({"game_id": ["G-000"], "team_id": ["T-000"], "week": [1], "target": [0.0]})
-    folds = forward_chaining_schedule(dummy["week"].to_list())
-    train_baseline(dummy)
-    print(f"[train] generated {len(folds)} forward-chaining folds")
-    print("[train] calibration plot scaffold pending data availability")
+    features = _load_feature_table()
+    summary = train_baseline(features)
+    print(
+        "[train] baseline complete | folds={folds} | calibration={calibration_method}"
+        .format(**summary)
+    )
+    print(f"[train] predictions saved to {summary['predictions_path']}")
+    print(f"[train] reliability plot saved to {summary['reliability_plot']}")
 
 
 if __name__ == "__main__":

--- a/a22a/sim/run.py
+++ b/a22a/sim/run.py
@@ -1,51 +1,180 @@
-"""Simulation scaffolding."""
+"""Drive-level hazard simulation with antithetic QMC."""
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Iterable, List
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import numpy as np
+import polars as pl
+
+SIM_DIR = Path("data") / "sim"
+MODEL_PREDICTIONS = Path("data") / "model" / "win_probabilities.parquet"
 
 
 @dataclass
 class SimulationConfig:
-    num_draws: int = 16
-    convergence_tol: float = 0.01
+    num_draws: int = 256
+    ci_width: float = 0.05
+    min_draws: int = 32
 
 
-class EarlyStop(Exception):
-    """Raised when the simulation meets early-stop criteria."""
+def _van_der_corput(n: int, base: int) -> np.ndarray:
+    sequence = np.zeros(n)
+    for i in range(n):
+        denominator = 1
+        index = i + 1
+        value = 0.0
+        while index:
+            index, remainder = divmod(index, base)
+            denominator *= base
+            value += remainder / denominator
+        sequence[i] = value
+    return sequence
 
 
-def quasi_monte_carlo_sampler(num_draws: int) -> List[float]:
-    return [idx / num_draws for idx in range(num_draws)]
+def quasi_monte_carlo(num_draws: int, dimension: int) -> np.ndarray:
+    bases = [2, 3, 5, 7, 11, 13, 17, 19]
+    usable = bases[:dimension]
+    base_draws = np.column_stack([_van_der_corput(num_draws // 2, base) for base in usable])
+    antithetic = 1.0 - base_draws
+    draws = np.vstack([base_draws, antithetic])
+    if draws.shape[0] < num_draws:
+        repeats = np.tile(draws, (int(np.ceil(num_draws / draws.shape[0])), 1))
+        draws = repeats[:num_draws, :]
+    return draws
 
 
-def run_simulation(config: SimulationConfig, hook: Callable[[int, float], bool]) -> List[float]:
-    draws = quasi_monte_carlo_sampler(config.num_draws)
-    results: List[float] = []
-    for idx, draw in enumerate(draws, start=1):
-        results.append(draw)
-        if hook(idx, draw):
-            raise EarlyStop(f"Stopped after {idx} iterations")
-    return results
+def _load_drives() -> pl.DataFrame:
+    path = Path("staged") / "drives.parquet"
+    if not path.exists():
+        raise FileNotFoundError("Missing drives data – run `make ingest` first")
+    return pl.read_parquet(path)
 
 
-def fair_ladder(results: Iterable[float]) -> List[float]:
-    return sorted(results)
+def _load_team_games() -> pl.DataFrame:
+    path = Path("staged") / "team_games.parquet"
+    if not path.exists():
+        raise FileNotFoundError("Missing team games data – run `make ingest` first")
+    return pl.read_parquet(path)
+
+
+def _load_predictions() -> pl.DataFrame:
+    if not MODEL_PREDICTIONS.exists():
+        raise FileNotFoundError("Missing model predictions – run `make train` first")
+    return pl.read_parquet(MODEL_PREDICTIONS)
+
+
+def _drive_hazards(drives: pl.DataFrame) -> Dict[Tuple[str, str], List[Tuple[float, float]]]:
+    hazards: Dict[Tuple[str, str], List[Tuple[float, float]]] = {}
+    for row in drives.iter_rows(named=True):
+        key = (row["game_id"], row["team_id"])
+        prob = min(max(row["points"] / 7.0, 0.05), 0.95)
+        hazards.setdefault(key, []).append((prob, row["points"]))
+    return hazards
+
+
+def _adjust_probabilities(hazards: List[Tuple[float, float]], win_prob: float) -> List[Tuple[float, float]]:
+    adjusted = []
+    for prob, points in hazards:
+        shift = (win_prob - 0.5) * 0.2
+        adjusted_prob = float(np.clip(prob + shift, 0.01, 0.99))
+        adjusted.append((adjusted_prob, points))
+    return adjusted
+
+
+def _simulate_game(
+    game_id: str,
+    home_hazards: List[Tuple[float, float]],
+    away_hazards: List[Tuple[float, float]],
+    config: SimulationConfig,
+) -> Tuple[pl.DataFrame, pl.DataFrame]:
+    dimension = len(home_hazards) + len(away_hazards)
+    draws = quasi_monte_carlo(config.num_draws, dimension)
+
+    results = []
+    home_wins = 0
+    for iteration, draw in enumerate(draws, start=1):
+        home_draws = draw[: len(home_hazards)]
+        away_draws = draw[len(home_hazards) :]
+        home_score = sum(points if uniform < prob else 0.0 for (prob, points), uniform in zip(home_hazards, home_draws))
+        away_score = sum(points if uniform < prob else 0.0 for (prob, points), uniform in zip(away_hazards, away_draws))
+        margin = home_score - away_score
+        total = home_score + away_score
+        if margin > 0:
+            home_wins += 1
+        results.append((iteration, home_score, away_score, margin, total))
+        if iteration >= config.min_draws:
+            p_hat = home_wins / iteration
+            stderr = max(np.sqrt(p_hat * (1 - p_hat) / iteration), 1e-6)
+            width = 3.92 * stderr
+            if width <= config.ci_width:
+                break
+
+    result_frame = pl.DataFrame(results, schema=["iteration", "home_points", "away_points", "margin", "total_points"])
+    summary = pl.DataFrame(
+        {
+            "game_id": [game_id],
+            "simulations": [int(result_frame.height)],
+            "home_win_rate": [home_wins / result_frame.height],
+            "mean_margin": [result_frame["margin"].mean()],
+            "mean_total": [result_frame["total_points"].mean()],
+        }
+    )
+    return summary, result_frame
+
+
+def _ladder(frame: pl.DataFrame, game_id: str) -> pl.DataFrame:
+    quantiles = [0.1, 0.25, 0.5, 0.75, 0.9]
+    ladder_rows = []
+    for stat in ("margin", "total_points"):
+        series = frame[stat]
+        for q in quantiles:
+            ladder_rows.append((game_id, stat, q, series.quantile(q)))
+    return pl.DataFrame(ladder_rows, schema=["game_id", "stat", "quantile", "value"])
 
 
 def main() -> None:
+    drives = _load_drives()
+    team_games = _load_team_games()
+    predictions = _load_predictions()
+
+    hazards = _drive_hazards(drives)
+    prediction_map = (
+        team_games.join(predictions, on=["game_id", "team_id", "season", "week"], how="inner")
+        .filter(pl.col("is_home"))
+        .select(["game_id", "team_id", "opponent_id", "win_prob_calibrated"])
+    )
+
+    SIM_DIR.mkdir(parents=True, exist_ok=True)
+
+    summaries: List[pl.DataFrame] = []
+    ladders: List[pl.DataFrame] = []
+
     config = SimulationConfig()
 
-    def early_stop_hook(iteration: int, value: float) -> bool:
-        return value >= (1.0 - config.convergence_tol)
+    for row in prediction_map.iter_rows(named=True):
+        game_id = row["game_id"]
+        home_team = row["team_id"]
+        away_team = row["opponent_id"]
+        home_prob = float(row["win_prob_calibrated"])
+        away_prob = 1.0 - home_prob
+        home_hazard = _adjust_probabilities(hazards[(game_id, home_team)], home_prob)
+        away_hazard = _adjust_probabilities(hazards[(game_id, away_team)], away_prob)
+        summary, dist = _simulate_game(game_id, home_hazard, away_hazard, config)
+        ladder = _ladder(dist, game_id)
+        summaries.append(summary)
+        ladders.append(ladder)
+        dist.write_parquet(SIM_DIR / f"{game_id}_distribution.parquet")
+        ladder.write_parquet(SIM_DIR / f"{game_id}_ladder.parquet")
+        print(
+            f"[sim] {game_id}: sims={summary['simulations'][0]} home_win={summary['home_win_rate'][0]:.3f}"
+        )
 
-    try:
-        results = run_simulation(config, early_stop_hook)
-    except EarlyStop as exc:
-        print(f"[sim] early-stop triggered: {exc}")
-        results = []
-    ladder = fair_ladder(results)
-    print("[sim] ladder placeholder:", ladder)
+    if summaries:
+        pl.concat(summaries, how="vertical").write_parquet(SIM_DIR / "summary.parquet")
+    if ladders:
+        pl.concat(ladders, how="vertical").write_parquet(SIM_DIR / "ladder.parquet")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,12 @@ requires-python = ">=3.11"
 dependencies = [
     "pyyaml>=6.0",
     "polars>=0.20",
+    "numpy>=1.24",
+    "pandas>=2.0",
+    "matplotlib>=3.7",
+    "lightgbm>=4.0",
+    "scikit-learn>=1.3",
+    "pyarrow>=14.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- implement full data contracts and a deterministic synthetic ingest that stages pbp, drives, schedules, rosters, and team games
- build Polars-based feature engineering with PSI monitoring, leakage guards, and recency-decayed team strength inputs
- add LightGBM training with purged forward-chaining CV, probability calibration, and drive-level QMC simulations for game outcomes

## Testing
- make doctor
- make ingest
- make features
- make train
- make sim

------
https://chatgpt.com/codex/tasks/task_e_68df1af458e083329b6d49966982f0e8