### PR TITLE
phases 1–6 bootstrap

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,15 @@
-## What changed / Why
--
+## What changed / Why?
+- 
 
-## Weekly report
-[Link to weekly report](https://example.com)
+## Doctor Output
+```text
+(paste output of `make doctor` here)
+```
 
 ## Acceptance Checkboxes (Phases 1–6)
-[ ] Phase 1 — Scaffolding & Governance: doctor runs < 30s; run registry + seed policy in place
+[ ] Phase 1 — Scaffolding & Governance: doctor < 30s; run registry + seed policy present
 [ ] Phase 2 — Data Spine: staged/ dir created; contracts module stub with schema and join-key assertions; ingest target no-ops cleanly without data
 [ ] Phase 3 — Feature Store v1: Polars lazy pipeline stubs + leakage guard + PSI hook; features target no-ops cleanly
-[ ] Phase 4 — Baseline Model: training stub with forward-chaining CV placeholder; calibration plot scaffold; no odds usage
+[ ] Phase 4 — Baseline Model: training stub with purged forward-chaining CV placeholder; calibration plot scaffold; no odds usage
 [ ] Phase 5 — Bayesian Team Strength: module stub with recency decay config; returns dummy θ table with CI fields
 [ ] Phase 6 — Simulation Engine v1: run.py sim stub with QMC/CI interfaces and early-stop hooks; emits fair ladder placeholders

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 .env
 .venv/
 /data/
-/staged/*.parquet
-/staged/*.json
-/staged/*.csv
-/reports/
-a22a.egg-info/
+/staged/
+!staged/.gitkeep
 __pycache__/
+*.py[cod]
 .DS_Store
+*.egg-info/
+reports/

--- a/README.md
+++ b/README.md
@@ -1,9 +1,49 @@
 # All-22 Atlas (A22A)
 
-All-22 Atlas is a modular analytics platform for orchestrating data ingestion, feature engineering, baseline modelling, and simulation workflows for American football research while maintaining strict governance over seeds, configs, and operational SLOs. This bootstrap repo ships lightweight scaffolding for the first six phases so teams can iterate safely before data arrives.
+All-22 Atlas (A22A) is a research playground for exploring American football analytics with discipline.
+This bootstrap focuses on the first six phases of the platform so contributors can extend data, features,
+and models without sacrificing governance or reproducibility.
+
+## Phase Overview
+
+| Phase | Focus | Key Artefacts |
+| --- | --- | --- |
+| 1 | Scaffolding & Governance | Doctor checks, run registry, seed policy, CI harness |
+| 2 | Data Spine | `staged/` contract stubs, ingestion harness, schema enforcement |
+| 3 | Feature Store v1 | Polars lazy pipelines, leakage guard, PSI drift hook |
+| 4 | Baseline Model | Forward-chaining CV stub, calibration artefact placeholders |
+| 5 | Bayesian Team Strength | Recency decay configuration, dummy posterior export |
+| 6 | Simulation Engine v1 | QMC/CI hooks, slate orchestration scaffolding |
 
 ## Quickstart
-1. Create a virtual environment with Python 3.11 and install dependencies via `pip install -e .`.
-2. Copy `.env.sample` to `.env` and populate API keys.
-3. Run `make doctor` to verify the environment and governance scaffolding.
-4. Use the remaining make targets (`ingest`, `features`, `train`, `sim`, `report`) as you flesh out each phase.
+
+1. **Environment** – Install Python 3.11 and create a virtual environment (e.g. `python -m venv .venv && source .venv/bin/activate`).
+2. **Dependencies** – Install the project in editable mode: `pip install -e .[dev]`.
+3. **Secrets** – Copy `.env.sample` to `.env` and populate the required API keys.
+4. **Doctor** – Run `make doctor` to validate governance, seeds, and placeholder SLOs.
+5. **Workflow Targets** – Use the remaining Make targets (`make ingest`, `make features`, `make train`, `make sim`, `make report`) as you flesh out each phase.
+6. **CI** – Push changes and rely on the GitHub Actions workflow to run the doctor and unit tests.
+
+## Repository Layout
+
+```
+a22a/                  Python package with tools, data, features, models, sim, and reports
+configs/defaults.yaml  Centralised configuration (seeds, SLOs, knobs)
+staged/                Scratch area for intermediate artefacts (tracked empty)
+Makefile               Workflow entry points
+```
+
+## Governance Checklist
+
+- Seeds and configuration are centrally managed in YAML.
+- Secrets are injected via environment variables only.
+- Odds provider domains are explicitly banned from feature/model code.
+- SLOs for ETL, feature engineering, modelling, and simulation are asserted in the doctor.
+- Run registry entries ensure every execution is traceable.
+
+## Development Tips
+
+- Keep modules pure and side-effect free until explicitly required by later phases.
+- Extend tests alongside the doctor to guard contracts as they evolve.
+- Update `configs/defaults.yaml` when introducing new knobs; never hardcode values in code.
+

--- a/a22a/data/contracts.py
+++ b/a22a/data/contracts.py
@@ -1,261 +1,87 @@
-"""Data contracts for staged inputs.
-
-The Phase 1–2 ingest stack produces a family of staged Parquet artefacts that
-mirror a trimmed-down nflverse schema. This module provides reusable contracts
-that guard schema drift both for the in-memory records used during tests as
-well as the Polars frames that back the persisted parquet files.
-"""
+"""Data contracts and schema stubs for staged datasets."""
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Dict, Iterable, Mapping, Sequence
 
 import polars as pl
+import yaml
 
-__all__ = [
-    "JOIN_KEYS",
-    "STAGED_GAME_SCHEMA",
-    "DatasetContract",
-    "ContractViolation",
-    "validate_records",
-    "validate_frame",
-]
-
-
-@dataclass(frozen=True)
-class Field:
-    """Represents a required column in the staged schema."""
-
-    name: str
-    dtype: pl.DataType
-    optional: bool = False
-
-    def validate(self, frame: pl.DataFrame, dataset: str) -> None:
-        if self.name not in frame.columns:
-            raise ContractViolation(
-                dataset=dataset,
-                message=f"Missing required column '{self.name}'",
-                record_index=-1,
-            )
-        series = frame.get_column(self.name)
-        if series.null_count() > 0 and not self.optional:
-            raise ContractViolation(
-                dataset=dataset,
-                message=f"Column '{self.name}' contains null values",
-                record_index=-1,
-            )
-        if series.dtype != self.dtype:
-            try:
-                series.cast(self.dtype)
-            except Exception as exc:  # noqa: BLE001
-                raise ContractViolation(
-                    dataset=dataset,
-                    message=(
-                        f"Column '{self.name}' expected dtype {self.dtype}, "
-                        f"received {series.dtype}"
-                    ),
-                    record_index=-1,
-                ) from exc
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = REPO_ROOT / "configs" / "defaults.yaml"
 
 
 @dataclass(frozen=True)
 class DatasetContract:
-    """Contract definition for a staged dataset."""
+    """Lightweight dataset contract capturing join keys and expected schema."""
 
     name: str
-    fields: Sequence[Field]
-    primary_key: Sequence[str]
+    join_keys: Sequence[str]
+    schema: Mapping[str, str]
 
-    def validate_frame(self, frame: pl.DataFrame) -> pl.DataFrame:
-        if frame.is_empty():
-            return frame
-        for field in self.fields:
-            field.validate(frame, dataset=self.name)
-        missing_keys = set(self.primary_key) - set(frame.columns)
-        if missing_keys:
-            raise ContractViolation(
-                dataset=self.name,
-                message=f"Missing primary key columns: {sorted(missing_keys)}",
-                record_index=-1,
+    def validate_join_keys(self) -> None:
+        if not self.join_keys:
+            raise ValueError(f"Contract '{self.name}' missing join keys")
+        if len(set(self.join_keys)) != len(tuple(self.join_keys)):
+            raise ValueError(f"Contract '{self.name}' has duplicate join keys")
+
+    def lazy_frame(self) -> pl.LazyFrame:
+        """Return an empty lazy frame using the declared schema."""
+
+        dtype_mapping = {
+            "int64": pl.Int64,
+            "float64": pl.Float64,
+            "str": pl.Utf8,
+            "bool": pl.Boolean,
+        }
+        schema = {
+            column: dtype_mapping.get(dtype, pl.Utf8)
+            for column, dtype in self.schema.items()
+        }
+        return pl.LazyFrame(schema=schema)
+
+    def enforce(self, frame: pl.DataFrame) -> None:
+        missing = set(self.join_keys) - set(frame.columns)
+        if missing:
+            raise ValueError(
+                f"{self.name}: missing join key columns -> {sorted(missing)}"
             )
-        key_counts = frame.group_by(list(self.primary_key)).len()
-        duplicated_keys = key_counts.filter(pl.col("len") > 1)
-        if duplicated_keys.height > 0:
-            duplicated_key = duplicated_keys.row(0)
-            mask = pl.all_horizontal(
-                [pl.col(column) == value for column, value in zip(self.primary_key, duplicated_key)]
-            )
-            index = (
-                frame
-                .with_row_count()
-                .filter(mask)
-                .select("row_nr")
-                .to_series()
-                .to_list()[0]
-            )
-            raise ContractViolation(
-                dataset=self.name,
-                message="Primary key uniqueness violated",
-                record_index=int(index),
-            )
-        return frame
 
 
-@dataclass
-class ContractViolation(Exception):
-    """Raised when staged data fails to meet the expected schema."""
-
-    dataset: str
-    message: str
-    record_index: int
-
-    def __str__(self) -> str:  # pragma: no cover - repr convenience
-        return f"{self.dataset}: {self.message} (record={self.record_index})"
-
-
-STAGED_GAME_SCHEMA = {
-    "game_id": pl.Utf8,
-    "season": pl.Int64,
-    "week": pl.Int64,
-    "team_id": pl.Utf8,
-    "opponent_id": pl.Utf8,
-}
-
-JOIN_KEYS = {"game_id", "team_id"}
+def load_contracts(config_path: Path | None = None) -> Dict[str, DatasetContract]:
+    config_path = CONFIG_PATH if config_path is None else config_path
+    with config_path.open("r", encoding="utf-8") as fh:
+        defaults = yaml.safe_load(fh) or {}
+    datasets = (
+        defaults.get("contracts", {}).get("datasets", {})
+        if isinstance(defaults, dict)
+        else {}
+    )
+    contracts: Dict[str, DatasetContract] = {}
+    for name, payload in datasets.items():
+        join_keys = tuple(payload.get("join_keys", ()))
+        schema = payload.get("schema", {}) or {}
+        contracts[name] = DatasetContract(name=name, join_keys=join_keys, schema=schema)
+        contracts[name].validate_join_keys()
+    return contracts
 
 
-CONTRACTS: Mapping[str, DatasetContract] = {
-    "pbp": DatasetContract(
-        name="pbp",
-        primary_key=("game_id", "play_id"),
-        fields=(
-            Field("game_id", pl.Utf8),
-            Field("play_id", pl.Int64),
-            Field("drive_id", pl.Utf8),
-            Field("season", pl.Int64),
-            Field("week", pl.Int64),
-            Field("posteam", pl.Utf8),
-            Field("defteam", pl.Utf8),
-            Field("yards_gained", pl.Float64),
-            Field("scoring_margin", pl.Float64),
-            Field("success", pl.Boolean),
-        ),
-    ),
-    "drives": DatasetContract(
-        name="drives",
-        primary_key=("game_id", "drive_id"),
-        fields=(
-            Field("game_id", pl.Utf8),
-            Field("drive_id", pl.Utf8),
-            Field("season", pl.Int64),
-            Field("week", pl.Int64),
-            Field("team_id", pl.Utf8),
-            Field("result", pl.Utf8),
-            Field("plays", pl.Int64),
-            Field("yards", pl.Float64),
-            Field("points", pl.Float64),
-        ),
-    ),
-    "schedule": DatasetContract(
-        name="schedule",
-        primary_key=("game_id",),
-        fields=(
-            Field("game_id", pl.Utf8),
-            Field("season", pl.Int64),
-            Field("week", pl.Int64),
-            Field("home_team", pl.Utf8),
-            Field("away_team", pl.Utf8),
-            Field("home_points", pl.Int64),
-            Field("away_points", pl.Int64),
-            Field("game_datetime", pl.Datetime("ns")),
-            Field("venue", pl.Utf8),
-        ),
-    ),
-    "roster": DatasetContract(
-        name="roster",
-        primary_key=("season", "team_id", "player_id"),
-        fields=(
-            Field("season", pl.Int64),
-            Field("team_id", pl.Utf8),
-            Field("player_id", pl.Utf8),
-            Field("position", pl.Utf8),
-            Field("full_name", pl.Utf8),
-            Field("experience", pl.Int64, optional=True),
-        ),
-    ),
-    "team_games": DatasetContract(
-        name="team_games",
-        primary_key=("game_id", "team_id"),
-        fields=(
-            Field("game_id", pl.Utf8),
-            Field("season", pl.Int64),
-            Field("week", pl.Int64),
-            Field("team_id", pl.Utf8),
-            Field("opponent_id", pl.Utf8),
-            Field("is_home", pl.Boolean),
-            Field("points_for", pl.Int64),
-            Field("points_against", pl.Int64),
-            Field("margin", pl.Int64),
-            Field("total_points", pl.Int64),
-            Field("win", pl.Int64),
-            Field("game_datetime", pl.Datetime("ns")),
-        ),
-    ),
-    "team_strength": DatasetContract(
-        name="team_strength",
-        primary_key=("season", "week", "team_id"),
-        fields=(
-            Field("season", pl.Int64),
-            Field("week", pl.Int64),
-            Field("team_id", pl.Utf8),
-            Field("theta_mean", pl.Float64),
-            Field("theta_ci_lower", pl.Float64),
-            Field("theta_ci_upper", pl.Float64),
-            Field("samples", pl.Float64),
-        ),
-    ),
-}
+def assert_contract(dataset: str, frame: pl.DataFrame, *, config_path: Path | None = None) -> None:
+    contract_map = load_contracts(config_path=config_path)
+    if dataset not in contract_map:
+        raise KeyError(f"Unknown dataset '{dataset}'")
+    contract_map[dataset].enforce(frame)
 
 
-def _contract(dataset: str) -> DatasetContract:
-    try:
-        return CONTRACTS[dataset]
-    except KeyError as exc:  # pragma: no cover - defensive programming
-        raise KeyError(f"Unknown dataset '{dataset}'") from exc
-
-
-def _ensure_frame(records: Iterable[Mapping[str, object]]) -> pl.DataFrame:
-    return pl.DataFrame(list(records))
-
-
-def validate_records(records: Iterable[Mapping[str, object]], dataset: str = "team_games") -> bool:
-    """Validate staged records against a named contract.
-
-    Parameters
-    ----------
-    records:
-        Iterable of mapping-like records.
-    dataset:
-        Name of the dataset contract to evaluate.
-    """
-
-    records = list(records)
-    if not records:
-        return True
-    frame = _ensure_frame(records)
-    validate_frame(frame, dataset)
-    return True
-
-
-def validate_frame(frame: pl.DataFrame, dataset: str) -> pl.DataFrame:
-    """Validate a Polars frame against a dataset contract."""
-
-    contract = _contract(dataset)
-    return contract.validate_frame(frame)
+def assert_records(dataset: str, records: Iterable[Mapping[str, object]], *, config_path: Path | None = None) -> None:
+    frame = pl.DataFrame(list(records)) if records else pl.DataFrame()
+    assert_contract(dataset, frame, config_path=config_path)
 
 
 def main() -> None:
-    print("Data contracts module provides schema validation for staged inputs.")
+    contracts = load_contracts()
+    print(f"Contracts initialised -> {', '.join(sorted(contracts))}")
 
 
 if __name__ == "__main__":

--- a/a22a/data/ingest.py
+++ b/a22a/data/ingest.py
@@ -1,212 +1,44 @@
-"""Synthetic ETL ingest for the Atlas Phase 1–2 deliverables."""
+"""Phase 2 ingestion scaffold."""
 from __future__ import annotations
 
-from datetime import datetime
 from pathlib import Path
 from typing import Dict
 
 import polars as pl
 
-from .contracts import CONTRACTS, JOIN_KEYS, STAGED_GAME_SCHEMA, validate_frame
+from a22a.data import contracts
 
 STAGED_DIR = Path("staged")
 
 
 def ensure_staged_dir() -> Path:
-    STAGED_DIR.mkdir(exist_ok=True)
+    STAGED_DIR.mkdir(parents=True, exist_ok=True)
     return STAGED_DIR
 
 
-def _build_schedule(season: int) -> pl.DataFrame:
-    games = [
-        {
-            "game_id": "2023WK01-BUF-KC",
-            "season": season,
-            "week": 1,
-            "home_team": "KC",
-            "away_team": "BUF",
-            "home_points": 27,
-            "away_points": 24,
-            "game_datetime": datetime(2023, 9, 7, 20, 20),
-            "venue": "GEHA Field",
-        },
-        {
-            "game_id": "2023WK01-PHI-DAL",
-            "season": season,
-            "week": 1,
-            "home_team": "DAL",
-            "away_team": "PHI",
-            "home_points": 21,
-            "away_points": 17,
-            "game_datetime": datetime(2023, 9, 10, 16, 25),
-            "venue": "AT&T Stadium",
-        },
-        {
-            "game_id": "2023WK02-KC-PHI",
-            "season": season,
-            "week": 2,
-            "home_team": "PHI",
-            "away_team": "KC",
-            "home_points": 23,
-            "away_points": 26,
-            "game_datetime": datetime(2023, 9, 17, 13, 0),
-            "venue": "Lincoln Financial Field",
-        },
-        {
-            "game_id": "2023WK02-BUF-DAL",
-            "season": season,
-            "week": 2,
-            "home_team": "BUF",
-            "away_team": "DAL",
-            "home_points": 31,
-            "away_points": 20,
-            "game_datetime": datetime(2023, 9, 17, 16, 5),
-            "venue": "Highmark Stadium",
-        },
-    ]
-    return pl.DataFrame(games)
+def build_empty_tables() -> Dict[str, pl.DataFrame]:
+    """Create empty tables based on configured contracts."""
+
+    tables: Dict[str, pl.DataFrame] = {}
+    for name, contract in contracts.load_contracts().items():
+        lazy = contract.lazy_frame()
+        tables[name] = lazy.collect()
+    return tables
 
 
-def _build_roster(season: int) -> pl.DataFrame:
-    players = [
-        {"season": season, "team_id": team, "player_id": f"{team}-{idx:02d}", "position": pos, "full_name": name, "experience": exp}
-        for team, roster in {
-            "BUF": [("QB", "Josh Allen", 6), ("WR", "Stefon Diggs", 8)],
-            "KC": [("QB", "Patrick Mahomes", 6), ("TE", "Travis Kelce", 10)],
-            "PHI": [("QB", "Jalen Hurts", 4), ("WR", "A.J. Brown", 5)],
-            "DAL": [("QB", "Dak Prescott", 8), ("WR", "CeeDee Lamb", 4)],
-        }.items()
-        for idx, (pos, name, exp) in enumerate(roster, start=1)
-    ]
-    return pl.DataFrame(players)
-
-
-def _build_drives_and_pbp(schedule: pl.DataFrame) -> Dict[str, pl.DataFrame]:
-    pbp_rows = []
-    drive_rows = []
-    play_id = 1
-    for game in schedule.iter_rows(named=True):
-        for team_id, opponent_id, is_home in (
-            (game["home_team"], game["away_team"], True),
-            (game["away_team"], game["home_team"], False),
-        ):
-            for drive_idx in range(1, 4):
-                drive_id = f"{team_id}-D{drive_idx}"
-                yards = 25 + 10 * drive_idx + (3 if is_home else 0)
-                points = 7.0 if drive_idx % 2 == 0 else 3.0
-                result = "TD" if points >= 7 else "FG"
-                drive_rows.append(
-                    {
-                        "game_id": game["game_id"],
-                        "drive_id": drive_id,
-                        "season": game["season"],
-                        "week": game["week"],
-                        "team_id": team_id,
-                        "result": result,
-                        "plays": 6 + drive_idx,
-                        "yards": float(yards),
-                        "points": points,
-                    }
-                )
-                for play_offset in range(1, 4):
-                    yards_gained = float(4 * play_offset + (2 if result == "TD" else 0))
-                    scoring_margin = (points if result == "TD" else points - 3) + (drive_idx - 2)
-                    pbp_rows.append(
-                        {
-                            "game_id": game["game_id"],
-                            "play_id": play_id,
-                            "drive_id": drive_id,
-                            "season": game["season"],
-                            "week": game["week"],
-                            "posteam": team_id,
-                            "defteam": opponent_id,
-                            "yards_gained": yards_gained,
-                            "scoring_margin": float(scoring_margin),
-                            "success": yards_gained >= 4.0,
-                        }
-                    )
-                    play_id += 1
-    pbp = pl.DataFrame(pbp_rows)
-    drives = pl.DataFrame(drive_rows)
-    return {"pbp": pbp, "drives": drives}
-
-
-def _build_team_games(schedule: pl.DataFrame) -> pl.DataFrame:
-    home = schedule.select(
-        [
-            pl.col("game_id"),
-            pl.col("season"),
-            pl.col("week"),
-            pl.col("home_team").alias("team_id"),
-            pl.col("away_team").alias("opponent_id"),
-            pl.lit(True).alias("is_home"),
-            pl.col("home_points").alias("points_for"),
-            pl.col("away_points").alias("points_against"),
-            pl.col("game_datetime"),
-        ]
-    )
-    away = schedule.select(
-        [
-            pl.col("game_id"),
-            pl.col("season"),
-            pl.col("week"),
-            pl.col("away_team").alias("team_id"),
-            pl.col("home_team").alias("opponent_id"),
-            pl.lit(False).alias("is_home"),
-            pl.col("away_points").alias("points_for"),
-            pl.col("home_points").alias("points_against"),
-            pl.col("game_datetime"),
-        ]
-    )
-    team_games = pl.concat([home, away]).with_columns(
-        (pl.col("points_for") - pl.col("points_against")).alias("margin"),
-        (pl.col("points_for") + pl.col("points_against")).alias("total_points"),
-        pl.when(pl.col("points_for") > pl.col("points_against")).then(1).otherwise(0).alias("win"),
-    )
-    return team_games.sort(["season", "week", "game_id", "team_id"])
-
-
-def load_raw_sources() -> Dict[str, pl.DataFrame]:
-    """Produce deterministic sample datasets that satisfy the data contracts."""
-
-    season = 2023
-    schedule = _build_schedule(season)
-    roster = _build_roster(season)
-    staged = _build_drives_and_pbp(schedule)
-    staged["schedule"] = schedule
-    staged["roster"] = roster
-    staged["team_games"] = _build_team_games(schedule)
-    return staged
-
-
-def apply_contract(frames: Dict[str, pl.DataFrame]) -> None:
-    for name, frame in frames.items():
-        dataset_name = name if name in CONTRACTS else "team_games"
-        validate_frame(frame, dataset_name)
-
-
-def _stage_frame(name: str, frame: pl.DataFrame) -> Path:
-    path = STAGED_DIR / f"{name}.parquet"
-    frame.write_parquet(path)
-    return path
+def validate_tables(tables: Dict[str, pl.DataFrame]) -> None:
+    for name, frame in tables.items():
+        contracts.assert_contract(name, frame)
 
 
 def main() -> None:
     ensure_staged_dir()
-    frames = load_raw_sources()
-    apply_contract(frames)
-    materialised = {name: _stage_frame(name, frame) for name, frame in frames.items()}
-    summary = ", ".join(f"{name}={frame.height}" for name, frame in frames.items())
-    print(
-        "[ingest] staged datasets with schema keys",
-        sorted(STAGED_GAME_SCHEMA),
-        "join keys",
-        sorted(JOIN_KEYS),
-        f"records -> {summary}",
-    )
-    print("[ingest] materialised:")
-    for name, path in materialised.items():
-        print(f"    - {name}: {path}")
+    tables = build_empty_tables()
+    validate_tables(tables)
+    print("[ingest] staged directory ready at", ensure_staged_dir())
+    print("[ingest] no raw sources available yet; produced empty tables:")
+    for name, frame in tables.items():
+        print(f"    - {name}: {frame.shape[0]} rows, columns={frame.columns}")
 
 
 if __name__ == "__main__":

--- a/a22a/features/build.py
+++ b/a22a/features/build.py
@@ -1,181 +1,103 @@
-"""Feature engineering pipeline for phases 3–5."""
+"""Feature engineering scaffold for Phase 3."""
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, Iterable, Sequence
 
 import numpy as np
 import polars as pl
+import yaml
 
-from a22a.models import team_strength as team_strength_module
-
-STAGED_DIR = Path("staged")
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = REPO_ROOT / "configs" / "defaults.yaml"
 FEATURE_DIR = Path("data") / "features"
 REFERENCE_PATH = FEATURE_DIR / "reference.parquet"
 
 
-def _ensure_team_strength() -> Path:
-    output = STAGED_DIR / "team_strength.parquet"
-    if not output.exists():
-        team_strength_module.main()
-    return output
+def load_config() -> Dict[str, object]:
+    with CONFIG_PATH.open("r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh) or {}
 
 
-def _scan_staged(name: str) -> pl.LazyFrame:
-    path = STAGED_DIR / f"{name}.parquet"
-    if not path.exists():
-        raise FileNotFoundError(f"Expected staged dataset {path}; run `make ingest`." )
-    return pl.scan_parquet(path)
+def lazy_sources(datasets: Iterable[str]) -> Dict[str, pl.LazyFrame]:
+    schemas = {
+        "team_games": {"season": pl.Int64, "week": pl.Int64, "game_id": pl.Utf8, "team_id": pl.Utf8},
+        "team_strength": {"season": pl.Int64, "week": pl.Int64, "team_id": pl.Utf8},
+    }
+    tables: Dict[str, pl.LazyFrame] = {}
+    for name in datasets:
+        tables[name] = pl.LazyFrame(schema=schemas.get(name, {}))
+    return tables
 
 
-def leakage_guard(features: pl.DataFrame) -> None:
-    required = {"game_id", "team_id", "season", "week", "target"}
-    missing = required - set(features.columns)
+def leakage_guard(frame: pl.DataFrame, required: Sequence[str]) -> None:
+    missing = set(required) - set(frame.columns)
     if missing:
-        raise ValueError(f"Leakage guard failed: missing {sorted(missing)}")
-    duplicates = features.group_by(["game_id", "team_id"]).len().filter(pl.col("len") > 1)
-    if duplicates.height > 0:
-        raise ValueError("Leakage guard failed: duplicate game/team rows detected")
-    if (features["week"] <= 0).any():
-        raise ValueError("Leakage guard failed: invalid week values detected")
+        raise ValueError(f"Leakage guard failed; missing columns -> {sorted(missing)}")
+    duplicates = frame.group_by(["game_id", "team_id"]).len()
+    if not duplicates.filter(pl.col("len") > 1).is_empty():
+        raise ValueError("Leakage guard failed; duplicate game/team rows detected")
 
 
-def _psi(reference: np.ndarray, current: np.ndarray, bins: int = 10) -> float:
-    hist_ref, edges = np.histogram(reference, bins=bins)
-    hist_cur, _ = np.histogram(current, bins=edges)
-    ref_pct = np.maximum(hist_ref / hist_ref.sum(), 1e-6)
-    cur_pct = np.maximum(hist_cur / hist_cur.sum(), 1e-6)
-    return float(np.sum((cur_pct - ref_pct) * np.log(cur_pct / ref_pct)))
-
-
-def compute_psi(reference: pl.DataFrame, current: pl.DataFrame) -> Dict[str, float]:
+def compute_psi(reference: pl.DataFrame, current: pl.DataFrame, bins: int) -> Dict[str, float]:
     if reference.is_empty() or current.is_empty():
         return {}
-    numeric_columns = [
-        column
-        for column, dtype in current.schema.items()
-        if dtype.is_numeric() and column not in {"season", "week", "target"}
-    ]
     scores: Dict[str, float] = {}
-    for column in numeric_columns:
-        scores[column] = _psi(reference[column].to_numpy(), current[column].to_numpy())
+    numeric = [column for column, dtype in current.schema.items() if dtype.is_numeric()]
+    for column in numeric:
+        ref = reference[column].to_numpy()
+        cur = current[column].to_numpy()
+        hist_ref, edges = np.histogram(ref, bins=bins)
+        hist_cur, _ = np.histogram(cur, bins=edges)
+        ref_pct = np.maximum(hist_ref / hist_ref.sum(), 1e-6)
+        cur_pct = np.maximum(hist_cur / hist_cur.sum(), 1e-6)
+        scores[column] = float(np.sum((cur_pct - ref_pct) * np.log(cur_pct / ref_pct)))
     return scores
 
 
-def build_feature_view() -> pl.LazyFrame:
-    _ensure_team_strength()
-
-    team_games = _scan_staged("team_games")
-    pbp = _scan_staged("pbp")
-    drives = _scan_staged("drives")
-    team_strength = _scan_staged("team_strength")
-
-    pbp_features = (
-        pbp.with_columns(pl.col("posteam").alias("team_id"))
-        .group_by(["season", "week", "game_id", "team_id"])
-        .agg(
-            pl.len().alias("plays"),
-            pl.col("yards_gained").mean().alias("avg_yards_gained"),
-            pl.col("yards_gained").max().alias("max_yards_gained"),
-            pl.col("success").mean().alias("success_rate"),
-            pl.col("scoring_margin").mean().alias("avg_scoring_margin_post"),
-        )
-    )
-
-    drive_features = (
-        drives.group_by(["season", "week", "game_id", "team_id"])
-        .agg(
-            pl.sum("points").alias("drive_points"),
-            pl.mean("points").alias("avg_drive_points"),
-            pl.sum("yards").alias("drive_yards"),
-            (pl.sum("points") / pl.sum("plays")).alias("points_per_play"),
-        )
-        .with_columns(
-            pl.col("drive_points").fill_null(0.0),
-            pl.col("avg_drive_points").fill_null(0.0),
-            pl.col("drive_yards").fill_null(0.0),
-            pl.col("points_per_play").fill_null(0.0),
-        )
-    )
-
-    lagged_team = (
-        team_games.with_columns(
-            pl.col("margin").shift(1).over("team_id").alias("lag_margin"),
-            pl.col("win").shift(1).over("team_id").alias("lag_win"),
-            pl.col("points_for").shift(1).over("team_id").alias("lag_points_for"),
-            pl.col("points_against").shift(1).over("team_id").alias("lag_points_against"),
-        )
-        .with_columns(
-            pl.col("lag_margin").fill_null(0.0),
-            pl.col("lag_win").fill_null(0.0),
-            pl.col("lag_points_for").fill_null(0.0),
-            pl.col("lag_points_against").fill_null(0.0),
-            pl.col("lag_margin").rolling_mean(window_size=3).over("team_id").fill_null(0.0).alias("rolling_margin_3"),
-        )
-    )
-
+def build_features(config: Dict[str, object]) -> pl.LazyFrame:
+    sources = lazy_sources(["team_games", "team_strength"])
+    team_games = sources["team_games"].with_columns(pl.lit(0.0).alias("margin"))
+    team_strength = sources["team_strength"].with_columns(pl.lit(0.0).alias("theta_mean"))
     features = (
-        lagged_team
-        .join(pbp_features, on=["season", "week", "game_id", "team_id"], how="left")
-        .join(drive_features, on=["season", "week", "game_id", "team_id"], how="left")
-        .join(team_strength, on=["season", "week", "team_id"], how="left")
+        team_games
+        .join(team_strength, on=["season", "week"], how="left")
+        .with_columns(pl.lit(0.0).alias("target"))
     )
-
-    opponent_strength = team_strength.rename({
-        "team_id": "opponent_id",
-        "theta_mean": "opponent_theta_mean",
-        "theta_ci_lower": "opponent_theta_ci_lower",
-        "theta_ci_upper": "opponent_theta_ci_upper",
-        "samples": "opponent_strength_samples",
-    })
-
-    features = (
-        features.join(opponent_strength, on=["season", "week", "opponent_id"], how="left")
-        .with_columns(
-            pl.col("theta_mean").fill_null(0.0),
-            pl.col("opponent_theta_mean").fill_null(0.0),
-            (pl.col("theta_mean") - pl.col("opponent_theta_mean")).alias("theta_diff"),
-            pl.col("win").cast(pl.Float64).alias("target"),
-        )
-    )
-
     return features
 
 
-def _materialize_weekly(features: pl.DataFrame) -> List[Path]:
+def materialise(features: pl.LazyFrame, config: Dict[str, object]) -> Dict[str, object]:
+    feature_cfg = config.get("feature_store", {})
+    required = feature_cfg.get("leakage_guard_columns", [])
+    bins = int(feature_cfg.get("psi_bins", 10))
+
     FEATURE_DIR.mkdir(parents=True, exist_ok=True)
-    written: List[Path] = []
-    for (season, week), frame in features.group_by(["season", "week"], maintain_order=True):
-        season_dir = FEATURE_DIR / f"season={season}"
-        season_dir.mkdir(parents=True, exist_ok=True)
-        path = season_dir / f"week={int(week):02d}.parquet"
-        frame.write_parquet(path)
-        written.append(path)
-    return written
+    frame = features.collect()
+    leakage_guard(frame, required)
 
-
-def materialize(features: pl.LazyFrame) -> Dict[str, object]:
-    current = features.collect()
-    leakage_guard(current)
-    psi_scores: Dict[str, float]
     if REFERENCE_PATH.exists():
         reference = pl.read_parquet(REFERENCE_PATH)
-        psi_scores = compute_psi(reference, current)
+        psi = compute_psi(reference, frame, bins)
     else:
-        psi_scores = {}
-    FEATURE_DIR.mkdir(parents=True, exist_ok=True)
-    current.write_parquet(REFERENCE_PATH)
-    paths = _materialize_weekly(current)
-    return {"paths": paths, "psi": psi_scores, "rows": current.height}
+        psi = {}
+    frame.write_parquet(REFERENCE_PATH)
+    return {"rows": frame.height, "psi": psi, "path": REFERENCE_PATH}
 
 
 def main() -> None:
-    STAGED_DIR.mkdir(exist_ok=True)
-    features = build_feature_view()
-    artefacts = materialize(features)
-    psi_summary = ", ".join(f"{k}={v:.4f}" for k, v in sorted(artefacts["psi"].items())) or "n/a"
-    print(f"[features] materialised {artefacts['rows']} rows -> {len(artefacts['paths'])} weekly files")
-    print(f"[features] psi drift summary: {psi_summary}")
+    config = load_config()
+    features = build_features(config)
+    artefacts = materialise(features, config)
+    print(
+        f"[features] wrote reference table to {artefacts['path']} "
+        f"with {artefacts['rows']} rows"
+    )
+    if artefacts["psi"]:
+        summary = ", ".join(f"{k}={v:.4f}" for k, v in artefacts["psi"].items())
+        print(f"[features] psi drift summary -> {summary}")
+    else:
+        print("[features] psi drift summary -> n/a (no reference)")
 
 
 if __name__ == "__main__":

--- a/a22a/models/team_strength.py
+++ b/a22a/models/team_strength.py
@@ -1,93 +1,70 @@
-"""Bayesian-style team strength estimates with recency decay."""
+"""Bayesian team strength scaffold for Phase 5."""
 from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Iterable, Mapping
+from typing import Dict, Iterable, Sequence
 
 import polars as pl
 import yaml
 
-from a22a.data.contracts import validate_frame
-
-CONFIG_PATH = Path(__file__).resolve().parents[2] / "configs" / "team_strength.yaml"
-STAGED_DIR = Path(__file__).resolve().parents[2] / "staged"
-
-
-@dataclass
-class TeamState:
-    mean: float = 0.0
-    samples: float = 1.0
-
-    def decay(self, factor: float) -> None:
-        self.mean *= factor
-        self.samples = max(self.samples * factor, 1.0)
-
-    def update(self, observation: float) -> None:
-        weight = self.samples
-        self.samples += 1.0
-        self.mean = (self.mean * weight + observation) / self.samples
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = REPO_ROOT / "configs" / "defaults.yaml"
+STAGED_DIR = REPO_ROOT / "staged"
+OUTPUT_PATH = STAGED_DIR / "team_strength.parquet"
 
 
-def load_config() -> Dict[str, float]:
+@dataclass(frozen=True)
+class StrengthConfig:
+    recency_decay: float
+    min_games: int
+
+
+def load_config() -> StrengthConfig:
     with CONFIG_PATH.open("r", encoding="utf-8") as fh:
-        cfg = yaml.safe_load(fh) or {}
-    return cfg
+        defaults = yaml.safe_load(fh) or {}
+    cfg = defaults.get("models", {}).get("team_strength", {})
+    return StrengthConfig(
+        recency_decay=float(cfg.get("recency_decay", 0.85)),
+        min_games=int(cfg.get("min_games", 3)),
+    )
 
 
-def _prepare_states(teams: Iterable[str]) -> Dict[str, TeamState]:
-    return {team: TeamState() for team in teams}
-
-
-def _scaled_margin(row: Mapping[str, object]) -> float:
-    margin = float(row["margin"])
-    total = max(float(row["total_points"]), 1.0)
-    return margin / total * 10.0
-
-
-def compute_team_strength(team_games: pl.DataFrame) -> pl.DataFrame:
-    cfg = load_config()
-    decay = float(cfg.get("recency_decay", 0.85))
-    prior_scale = float(cfg.get("prior_scale", 1.0))
-
-    team_games = team_games.sort(["season", "week", "game_datetime", "team_id"])
-    teams = team_games.get_column("team_id").unique().to_list()
-    states = _prepare_states(teams)
-
+def run_stub(config: StrengthConfig, teams: Sequence[str]) -> pl.DataFrame:
     records = []
-    for row in team_games.iter_rows(named=True):
-        state = states[row["team_id"]]
-        state.decay(decay)
-        std = prior_scale / (state.samples**0.5)
+    for team in teams:
         records.append(
             {
-                "season": row["season"],
-                "week": row["week"],
-                "team_id": row["team_id"],
-                "theta_mean": state.mean,
-                "theta_ci_lower": state.mean - 1.96 * std,
-                "theta_ci_upper": state.mean + 1.96 * std,
-                "samples": state.samples,
+                "season": 2023,
+                "week": 1,
+                "team_id": team,
+                "theta_mean": 0.0,
+                "theta_ci_lower": -0.1,
+                "theta_ci_upper": 0.1,
+                "samples": float(config.min_games),
             }
         )
-        observation = _scaled_margin(row)
-        state.update(observation)
+    return pl.DataFrame(records, schema={
+        "season": pl.Int64,
+        "week": pl.Int64,
+        "team_id": pl.Utf8,
+        "theta_mean": pl.Float64,
+        "theta_ci_lower": pl.Float64,
+        "theta_ci_upper": pl.Float64,
+        "samples": pl.Float64,
+    })
 
-    frame = pl.DataFrame(records)
-    if not frame.is_empty():
-        validate_frame(frame, "team_strength")
-    return frame
 
-
-def main() -> None:
-    team_games_path = STAGED_DIR / "team_games.parquet"
-    if not team_games_path.exists():
-        raise FileNotFoundError(f"Expected {team_games_path} – run `make ingest` first")
-    team_games = pl.read_parquet(team_games_path)
-    strength = compute_team_strength(team_games)
-    output = STAGED_DIR / "team_strength.parquet"
-    strength.write_parquet(output)
-    print(f"[team-strength] computed {strength.height} rows -> {output}")
+def main(teams: Iterable[str] | None = None) -> None:
+    config = load_config()
+    STAGED_DIR.mkdir(parents=True, exist_ok=True)
+    team_list = list(teams) if teams is not None else ["BUF", "KC"]
+    table = run_stub(config, team_list)
+    table.write_parquet(OUTPUT_PATH)
+    print(
+        f"[team-strength] stub complete | teams={len(team_list)} | decay={config.recency_decay}"
+    )
+    print(f"[team-strength] output -> {OUTPUT_PATH}")
 
 
 if __name__ == "__main__":

--- a/a22a/models/train_baseline.py
+++ b/a22a/models/train_baseline.py
@@ -1,239 +1,89 @@
-"""LightGBM baseline with purged forward chaining and calibration."""
+"""Baseline model training scaffold for Phase 4."""
 from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Sequence
 
-import lightgbm as lgb
-import matplotlib.pyplot as plt
 import numpy as np
-import pandas as pd
 import polars as pl
-from sklearn.calibration import calibration_curve
-from sklearn.isotonic import IsotonicRegression
-from sklearn.linear_model import LogisticRegression
-from sklearn.metrics import brier_score_loss, log_loss
+import yaml
 
-FEATURE_DIR = Path("data") / "features"
-MODEL_DIR = Path("data") / "model"
-REPORT_DIR = Path("reports")
-PREDICTION_PATH = MODEL_DIR / "win_probabilities.parquet"
-RELIABILITY_PATH = REPORT_DIR / "reliability.png"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = REPO_ROOT / "configs" / "defaults.yaml"
+FEATURE_REFERENCE = Path("data") / "features" / "reference.parquet"
+MODEL_DIR = Path("data") / "models"
+PLOTS_DIR = Path("reports") / "baseline"
+CALIBRATION_PLOT = PLOTS_DIR / "calibration_placeholder.png"
 
 
-@dataclass
-class ForwardChainingFold:
-    train_weeks: List[int]
-    validation_weeks: List[int]
+@dataclass(frozen=True)
+class Fold:
+    train_weeks: Sequence[int]
+    validation_weeks: Sequence[int]
 
 
-def forward_chaining_schedule(weeks: Iterable[int], purge_gap: int = 1) -> List[ForwardChainingFold]:
+def load_config() -> Dict[str, object]:
+    with CONFIG_PATH.open("r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh) or {}
+
+
+def load_features() -> pl.DataFrame:
+    if FEATURE_REFERENCE.exists():
+        return pl.read_parquet(FEATURE_REFERENCE)
+    return pl.DataFrame(
+        {
+            "season": [],
+            "week": [],
+            "game_id": [],
+            "team_id": [],
+            "target": [],
+        }
+    )
+
+
+def forward_chaining_schedule(weeks: Iterable[int], purge_gap: int) -> List[Fold]:
     ordered = sorted(set(int(week) for week in weeks))
-    folds: List[ForwardChainingFold] = []
-    for idx, validation_week in enumerate(ordered[1:], start=1):
+    folds: List[Fold] = []
+    for idx in range(1, len(ordered)):
+        validation_week = ordered[idx]
         train_cutoff = validation_week - purge_gap
         train_weeks = [week for week in ordered[:idx] if week <= train_cutoff]
         if not train_weeks:
             continue
-        folds.append(ForwardChainingFold(train_weeks=train_weeks, validation_weeks=[validation_week]))
+        folds.append(Fold(train_weeks=train_weeks, validation_weeks=[validation_week]))
     return folds
 
 
-def _iter_feature_files() -> List[Path]:
-    """Return the partitioned feature parquet paths in deterministic order."""
-
-    if not FEATURE_DIR.exists():
-        raise FileNotFoundError("Feature directory missing – run `make features` first")
-
-    # Only include partitioned weekly files to avoid double counting the
-    # reference snapshot written alongside them.
-    paths = sorted(FEATURE_DIR.glob("season=*/week=*.parquet"))
-    if not paths:
-        raise FileNotFoundError("No feature parquet files found")
-    return paths
+def calibration_stub(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("calibration placeholder", encoding="utf-8")
+    return path
 
 
-def _load_feature_table() -> pl.DataFrame:
-    frames = [pl.read_parquet(path) for path in _iter_feature_files()]
-    return pl.concat(frames, how="vertical")
-
-
-def _encode_categoricals(frame: pd.DataFrame, categorical_columns: Iterable[str]) -> pd.DataFrame:
-    encoded = frame.copy()
-    for column in categorical_columns:
-        encoded[column] = encoded[column].astype("category").cat.codes
-    return encoded
-
-
-def _prepare_design_matrix(features: pl.DataFrame) -> tuple[pd.DataFrame, pd.Series, List[str]]:
-    df = features.to_pandas()
-    categorical_columns = ["team_id", "opponent_id"]
-    df = _encode_categoricals(df, categorical_columns)
-    drop_columns = {"game_id", "game_datetime", "target"}
-    feature_columns = [column for column in df.columns if column not in drop_columns]
-    X = df[feature_columns]
-    y = df["target"].astype(float)
-    return X, y, feature_columns
-
-
-def _calibrate_probabilities(probs: np.ndarray, y_true: np.ndarray) -> tuple[np.ndarray, str]:
-    unique_labels = np.unique(y_true)
-    if unique_labels.shape[0] < 2:
-        return probs, "identity"
-    if len(y_true) < 10:
-        calibrator = LogisticRegression(max_iter=1000)
-        calibrator.fit(probs.reshape(-1, 1), y_true)
-        calibrated = calibrator.predict_proba(probs.reshape(-1, 1))[:, 1]
-        return calibrated, "platt"
-    calibrator = IsotonicRegression(out_of_bounds="clip")
-    calibrator.fit(probs, y_true)
-    calibrated = calibrator.transform(probs)
-    return calibrated, "isotonic"
-
-
-def _expected_calibration_error(y_true: np.ndarray, probs: np.ndarray, bins: int = 10) -> float:
-    """Compute the ECE using equally spaced bins."""
-
-    if len(probs) == 0:
-        return 0.0
-
-    bin_edges = np.linspace(0.0, 1.0, bins + 1)
-    bin_indices = np.digitize(probs, bin_edges, right=True)
-    total = len(probs)
-    ece = 0.0
-    for bin_id in range(1, bins + 1):
-        mask = bin_indices == bin_id
-        if not np.any(mask):
-            continue
-        bin_prob = probs[mask].mean()
-        bin_true = y_true[mask].mean()
-        weight = mask.sum() / total
-        ece += weight * abs(bin_true - bin_prob)
-    return float(ece)
-
-
-def _plot_reliability(y_true: np.ndarray, probs: np.ndarray) -> None:
-    REPORT_DIR.mkdir(parents=True, exist_ok=True)
-    prob_true, prob_pred = calibration_curve(y_true, probs, n_bins=5, strategy="uniform")
-    plt.figure(figsize=(5, 5))
-    plt.plot(prob_pred, prob_true, marker="o", label="Baseline")
-    plt.plot([0, 1], [0, 1], linestyle="--", color="gray", label="Perfect calibration")
-    plt.xlabel("Predicted win probability")
-    plt.ylabel("Empirical win rate")
-    plt.title("Win probability reliability")
-    plt.legend()
-    plt.grid(alpha=0.3)
-    plt.tight_layout()
-    plt.savefig(RELIABILITY_PATH, dpi=200)
-    plt.close()
-
-
-def train_baseline(features: pl.DataFrame) -> Dict[str, object]:
-    X, y, feature_columns = _prepare_design_matrix(features)
-    weeks = features["week"].to_list()
-    folds = forward_chaining_schedule(weeks)
-
+def train_stub(features: pl.DataFrame, folds: Sequence[Fold]) -> Dict[str, object]:
     MODEL_DIR.mkdir(parents=True, exist_ok=True)
-
-    oof_records: List[pd.DataFrame] = []
-    models: List[lgb.LGBMClassifier] = []
-
-    for fold_index, fold in enumerate(folds):
-        train_mask = X["week"].isin(fold.train_weeks)
-        val_mask = X["week"].isin(fold.validation_weeks)
-        if train_mask.sum() == 0 or val_mask.sum() == 0:
-            continue
-        model = lgb.LGBMClassifier(
-            objective="binary",
-            n_estimators=200,
-            learning_rate=0.05,
-            subsample=0.8,
-            colsample_bytree=0.8,
-            random_state=42,
-        )
-        model.fit(X[train_mask], y[train_mask])
-        val_probs = model.predict_proba(X[val_mask])[:, 1]
-        fold_df = pd.DataFrame(
-            {
-                "game_id": features.filter(pl.col("week").is_in(fold.validation_weeks))["game_id"].to_list(),
-                "team_id": features.filter(pl.col("week").is_in(fold.validation_weeks))["team_id"].to_list(),
-                "week": X.loc[val_mask, "week"].to_list(),
-                "season": X.loc[val_mask, "season"].to_list(),
-                "win_prob_raw": val_probs,
-                "target": y[val_mask].to_numpy(),
-                "fold": fold_index,
-            }
-        )
-        oof_records.append(fold_df)
-        models.append(model)
-
-    if not oof_records:
-        raise RuntimeError("Not enough data to perform forward-chaining CV")
-
-    oof_df = pd.concat(oof_records, ignore_index=True)
-    calibrated_probs, calibration_method = _calibrate_probabilities(
-        oof_df["win_prob_raw"].to_numpy(), oof_df["target"].to_numpy()
-    )
-    oof_df["win_prob_calibrated"] = calibrated_probs
-    _plot_reliability(oof_df["target"].to_numpy(), calibrated_probs)
-
-    y_true = oof_df["target"].to_numpy()
-    metrics = {
-        "brier_score": float(brier_score_loss(y_true, calibrated_probs)),
-        "log_loss": float(log_loss(y_true, np.clip(calibrated_probs, 1e-6, 1 - 1e-6))),
-        "ece": _expected_calibration_error(y_true, calibrated_probs),
+    model_path = MODEL_DIR / "baseline_model_placeholder.npz"
+    np.savez(model_path, metadata="baseline placeholder")
+    return {
+        "folds": len(folds),
+        "model_path": model_path,
     }
-
-    final_model = lgb.LGBMClassifier(
-        objective="binary",
-        n_estimators=300,
-        learning_rate=0.05,
-        subsample=0.9,
-        colsample_bytree=0.9,
-        random_state=21,
-    )
-    final_model.fit(X, y)
-    final_probs = final_model.predict_proba(X)[:, 1]
-    final_calibrated, _ = _calibrate_probabilities(final_probs, y.to_numpy())
-
-    prediction_table = pd.DataFrame(
-        {
-            "game_id": features["game_id"].to_list(),
-            "team_id": features["team_id"].to_list(),
-            "season": features["season"].to_list(),
-            "week": features["week"].to_list(),
-            "win_prob_raw": final_probs,
-            "win_prob_calibrated": final_calibrated,
-        }
-    )
-    pl.from_pandas(prediction_table).write_parquet(PREDICTION_PATH)
-
-    summary = {
-        "folds": len(oof_records),
-        "calibration_method": calibration_method,
-        "features": feature_columns,
-        "predictions_path": PREDICTION_PATH,
-        "reliability_plot": RELIABILITY_PATH,
-        **metrics,
-    }
-    return summary
 
 
 def main() -> None:
-    features = _load_feature_table()
-    summary = train_baseline(features)
+    config = load_config()
+    feature_table = load_features()
+    baseline_cfg = config.get("models", {}).get("baseline", {})
+    purge_gap = int(baseline_cfg.get("purging_weeks", 1))
+    folds = forward_chaining_schedule(feature_table.get_column("week") if "week" in feature_table.columns else [], purge_gap)
+    artefacts = train_stub(feature_table, folds)
+    calibration_stub(CALIBRATION_PLOT)
     print(
-        "[train] baseline complete | folds={folds} | calibration={calibration_method}"
-        .format(**summary)
+        "[train] baseline stub complete | folds=%s | model=%s"
+        % (artefacts["folds"], artefacts["model_path"])
     )
-    print(
-        "[train] metrics | brier={brier_score:.4f} | logloss={log_loss:.4f} | ece={ece:.4f}".format(
-            **summary
-        )
-    )
-    print(f"[train] predictions saved to {summary['predictions_path']}")
-    print(f"[train] reliability plot saved to {summary['reliability_plot']}")
+    print(f"[train] calibration placeholder -> {CALIBRATION_PLOT}")
 
 
 if __name__ == "__main__":

--- a/a22a/sim/run.py
+++ b/a22a/sim/run.py
@@ -1,188 +1,73 @@
-"""Drive-level hazard simulation with antithetic QMC."""
+"""Simulation engine scaffold for Phase 6."""
 from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, Iterable, Sequence
 
 import numpy as np
 import polars as pl
+import yaml
 
-SIM_DIR = Path("data") / "sim"
-MODEL_PREDICTIONS = Path("data") / "model" / "win_probabilities.parquet"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = REPO_ROOT / "configs" / "defaults.yaml"
+SIM_DIR = Path("staged") / "simulations"
 
 
-@dataclass
+@dataclass(frozen=True)
 class SimulationConfig:
-    num_draws: int = 256
-    ci_width: float = 0.05
-    min_draws: int = 32
+    sampler: str
+    max_sims_per_game: int
+    early_stop_margin: float
 
 
-def _van_der_corput(n: int, base: int) -> np.ndarray:
-    sequence = np.zeros(n)
-    for i in range(n):
-        denominator = 1
-        index = i + 1
-        value = 0.0
-        while index:
-            index, remainder = divmod(index, base)
-            denominator *= base
-            value += remainder / denominator
-        sequence[i] = value
-    return sequence
+def load_config() -> SimulationConfig:
+    with CONFIG_PATH.open("r", encoding="utf-8") as fh:
+        defaults = yaml.safe_load(fh) or {}
+    cfg = defaults.get("simulation", {})
+    return SimulationConfig(
+        sampler=str(cfg.get("qmc_sampler", "sobol")),
+        max_sims_per_game=int(cfg.get("max_sims_per_game", 1024)),
+        early_stop_margin=float(cfg.get("early_stop_margin", 0.01)),
+    )
 
 
-def quasi_monte_carlo(num_draws: int, dimension: int) -> np.ndarray:
+def quasi_monte_carlo(draws: int, dimension: int) -> np.ndarray:
     bases = [2, 3, 5, 7, 11, 13, 17, 19]
-    usable = bases[:dimension]
-    base_draws = np.column_stack([_van_der_corput(num_draws // 2, base) for base in usable])
-    antithetic = 1.0 - base_draws
-    draws = np.vstack([base_draws, antithetic])
-    if draws.shape[0] < num_draws:
-        repeats = np.tile(draws, (int(np.ceil(num_draws / draws.shape[0])), 1))
-        draws = repeats[:num_draws, :]
-    return draws
+    usable = bases[: max(dimension, 1)]
+    sequence = [np.arange(draws) / draws for _ in usable]
+    return np.column_stack(sequence[:dimension]) if dimension else np.empty((draws, 0))
 
 
-def _load_drives() -> pl.DataFrame:
-    path = Path("staged") / "drives.parquet"
-    if not path.exists():
-        raise FileNotFoundError("Missing drives data – run `make ingest` first")
-    return pl.read_parquet(path)
+def simulate_game_stub(config: SimulationConfig, teams: Sequence[str]) -> Dict[str, object]:
+    draws = quasi_monte_carlo(min(config.max_sims_per_game, 32), dimension=len(teams))
+    summary = {
+        "draws": draws.shape[0],
+        "sampler": config.sampler,
+        "early_stop_margin": config.early_stop_margin,
+    }
+    return summary
 
 
-def _load_team_games() -> pl.DataFrame:
-    path = Path("staged") / "team_games.parquet"
-    if not path.exists():
-        raise FileNotFoundError("Missing team games data – run `make ingest` first")
-    return pl.read_parquet(path)
-
-
-def _load_predictions() -> pl.DataFrame:
-    if not MODEL_PREDICTIONS.exists():
-        raise FileNotFoundError("Missing model predictions – run `make train` first")
-    return pl.read_parquet(MODEL_PREDICTIONS)
-
-
-def _drive_hazards(drives: pl.DataFrame) -> Dict[Tuple[str, str], List[Tuple[float, float]]]:
-    hazards: Dict[Tuple[str, str], List[Tuple[float, float]]] = {}
-    for row in drives.iter_rows(named=True):
-        key = (row["game_id"], row["team_id"])
-        prob = min(max(row["points"] / 7.0, 0.05), 0.95)
-        hazards.setdefault(key, []).append((prob, row["points"]))
-    return hazards
-
-
-def _adjust_probabilities(hazards: List[Tuple[float, float]], win_prob: float) -> List[Tuple[float, float]]:
-    adjusted = []
-    for prob, points in hazards:
-        shift = (win_prob - 0.5) * 0.2
-        adjusted_prob = float(np.clip(prob + shift, 0.01, 0.99))
-        adjusted.append((adjusted_prob, points))
-    return adjusted
-
-
-def _simulate_game(
-    game_id: str,
-    home_hazards: List[Tuple[float, float]],
-    away_hazards: List[Tuple[float, float]],
-    config: SimulationConfig,
-) -> Tuple[pl.DataFrame, pl.DataFrame]:
-    dimension = len(home_hazards) + len(away_hazards)
-    draws = quasi_monte_carlo(config.num_draws, dimension)
-
-    results = []
-    home_wins = 0
-    for iteration, draw in enumerate(draws, start=1):
-        home_draws = draw[: len(home_hazards)]
-        away_draws = draw[len(home_hazards) :]
-        home_score = sum(points if uniform < prob else 0.0 for (prob, points), uniform in zip(home_hazards, home_draws))
-        away_score = sum(points if uniform < prob else 0.0 for (prob, points), uniform in zip(away_hazards, away_draws))
-        margin = home_score - away_score
-        total = home_score + away_score
-        if margin > 0:
-            home_wins += 1
-        results.append((iteration, home_score, away_score, margin, total))
-        if iteration >= config.min_draws:
-            p_hat = home_wins / iteration
-            stderr = max(np.sqrt(p_hat * (1 - p_hat) / iteration), 1e-6)
-            width = 3.92 * stderr
-            if width <= config.ci_width:
-                break
-
-    result_frame = pl.DataFrame(
-        results,
-        schema=["iteration", "home_points", "away_points", "margin", "total_points"],
-        orient="row",
-    )
-    summary = pl.DataFrame(
-        {
-            "game_id": [game_id],
-            "simulations": [int(result_frame.height)],
-            "home_win_rate": [home_wins / result_frame.height],
-            "mean_margin": [result_frame["margin"].mean()],
-            "mean_total": [result_frame["total_points"].mean()],
-        }
-    )
-    return summary, result_frame
-
-
-def _ladder(frame: pl.DataFrame, game_id: str) -> pl.DataFrame:
-    quantiles = [0.1, 0.25, 0.5, 0.75, 0.9]
-    ladder_rows = []
-    for stat in ("margin", "total_points"):
-        series = frame[stat]
-        for q in quantiles:
-            ladder_rows.append((game_id, stat, q, series.quantile(q)))
-    return pl.DataFrame(
-        ladder_rows,
-        schema=["game_id", "stat", "quantile", "value"],
-        orient="row",
-    )
-
-
-def main() -> None:
-    drives = _load_drives()
-    team_games = _load_team_games()
-    predictions = _load_predictions()
-
-    hazards = _drive_hazards(drives)
-    prediction_map = (
-        team_games.join(predictions, on=["game_id", "team_id", "season", "week"], how="inner")
-        .filter(pl.col("is_home"))
-        .select(["game_id", "team_id", "opponent_id", "win_prob_calibrated"])
-    )
-
+def main(games: Iterable[str] | None = None) -> None:
+    config = load_config()
     SIM_DIR.mkdir(parents=True, exist_ok=True)
-
-    summaries: List[pl.DataFrame] = []
-    ladders: List[pl.DataFrame] = []
-
-    config = SimulationConfig()
-
-    for row in prediction_map.iter_rows(named=True):
-        game_id = row["game_id"]
-        home_team = row["team_id"]
-        away_team = row["opponent_id"]
-        home_prob = float(row["win_prob_calibrated"])
-        away_prob = 1.0 - home_prob
-        home_hazard = _adjust_probabilities(hazards[(game_id, home_team)], home_prob)
-        away_hazard = _adjust_probabilities(hazards[(game_id, away_team)], away_prob)
-        summary, dist = _simulate_game(game_id, home_hazard, away_hazard, config)
-        ladder = _ladder(dist, game_id)
-        summaries.append(summary)
-        ladders.append(ladder)
-        dist.write_parquet(SIM_DIR / f"{game_id}_distribution.parquet")
-        ladder.write_parquet(SIM_DIR / f"{game_id}_ladder.parquet")
-        print(
-            f"[sim] {game_id}: sims={summary['simulations'][0]} home_win={summary['home_win_rate'][0]:.3f}"
-        )
-
-    if summaries:
-        pl.concat(summaries, how="vertical").write_parquet(SIM_DIR / "summary.parquet")
-    if ladders:
-        pl.concat(ladders, how="vertical").write_parquet(SIM_DIR / "ladder.parquet")
+    slate = list(games) if games is not None else ["BUF@KC"]
+    results = {}
+    for game_id in slate:
+        summary = simulate_game_stub(config, teams=["home", "away"])
+        results[game_id] = summary
+    ladder_path = SIM_DIR / "fair_ladder_placeholder.parquet"
+    pl.DataFrame(
+        {
+            "game_id": list(results.keys()),
+            "sampler": [summary["sampler"] for summary in results.values()],
+            "draws": [summary["draws"] for summary in results.values()],
+        }
+    ).write_parquet(ladder_path)
+    print(
+        f"[sim] stub complete | games={len(slate)} | ladder={ladder_path}"
+    )
 
 
 if __name__ == "__main__":

--- a/a22a/tools/doctor.py
+++ b/a22a/tools/doctor.py
@@ -1,35 +1,39 @@
-"""Governance doctor for All-22 Atlas."""
+"""Governance doctor for All-22 Atlas (A22A)."""
 from __future__ import annotations
 
 import argparse
 import hashlib
 import os
+import random
 import re
 import sys
 import time
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
-from typing import Dict, Iterable, Mapping
+from typing import Dict, Iterable, Mapping, Sequence
 
+import numpy as np
 import yaml
 
-REQUIRED_ENV_KEYS = (
+REQUIRED_ENV_KEYS: Sequence[str] = (
     "OPENAI_API_KEY",
     "ODDS_API_KEY",
     "SPORTSGAMEODDS_API_KEY",
     "WEATHER_API_KEY",
 )
 
-ODDS_DOMAINS = (
+ODDS_DOMAINS: Sequence[str] = (
     "theoddsapi.com",
     "oddsapi.com",
     "sportsgameodds.com",
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-CONFIG_DIR = REPO_ROOT / "configs"
-FEATURE_DIR = REPO_ROOT / "a22a" / "features"
+CONFIG_PATH = REPO_ROOT / "configs" / "defaults.yaml"
 PACKAGE_DIR = REPO_ROOT / "a22a"
+FEATURE_DIR = PACKAGE_DIR / "features"
+MODEL_DIR = PACKAGE_DIR / "models"
 
 
 @dataclass
@@ -38,6 +42,7 @@ class SLORecord:
 
     name: str
     budget_seconds: float
+    description: str
 
 
 class SLOTimer:
@@ -49,30 +54,39 @@ class SLOTimer:
 
     def __enter__(self) -> "SLOTimer":
         self._start = time.perf_counter()
-        print(f"[doctor] starting SLO window for {self.record.name} (budget={self.record.budget_seconds}s)")
+        print(
+            f"[doctor] starting SLO window for {self.record.name} "
+            f"(budget={self.record.budget_seconds}s :: {self.record.description})"
+        )
         return self
 
     def __exit__(self, exc_type, exc, tb) -> bool:
         elapsed = time.perf_counter() - self._start
         status = "OK" if elapsed <= self.record.budget_seconds else "VIOLATION"
-        print(f"[doctor] completed {self.record.name} in {elapsed:.4f}s -> {status}")
+        print(
+            f"[doctor] completed {self.record.name} in {elapsed:.4f}s -> {status}"
+        )
         if elapsed > self.record.budget_seconds:
-            raise RuntimeError(f"SLO violation for {self.record.name}: {elapsed:.4f}s > {self.record.budget_seconds}s")
+            raise RuntimeError(
+                f"SLO violation for {self.record.name}: {elapsed:.4f}s > "
+                f"{self.record.budget_seconds}s"
+            )
         return False
 
 
-def _load_yaml(path: Path) -> Dict[str, object]:
+def load_defaults(path: Path = CONFIG_PATH) -> Dict[str, object]:
     if not path.exists():
-        raise FileNotFoundError(f"Expected config at {path}")
+        raise FileNotFoundError(
+            f"Configuration file missing: {path.relative_to(REPO_ROOT)}"
+        )
     with path.open("r", encoding="utf-8") as fh:
         data = yaml.safe_load(fh) or {}
     if not isinstance(data, dict):
-        raise ValueError(f"Config {path} must decode to a mapping")
+        raise ValueError("defaults.yaml must decode to a mapping")
     return data
 
 
-def compute_seed_hashes(seeds: Mapping[str, str]) -> Dict[str, str]:
-    """Return short SHA256 digests for configured seeds."""
+def compute_seed_hashes(seeds: Mapping[str, object]) -> Dict[str, str]:
     hashes: Dict[str, str] = {}
     for name, value in seeds.items():
         digest = hashlib.sha256(str(value).encode("utf-8")).hexdigest()
@@ -80,20 +94,36 @@ def compute_seed_hashes(seeds: Mapping[str, str]) -> Dict[str, str]:
     return hashes
 
 
+def set_global_seeds(seeds: Mapping[str, object]) -> None:
+    code_seed = int(seeds.get("code", 0))
+    data_seed = int(seeds.get("data", code_seed))
+    config_seed = int(seeds.get("config", code_seed))
+    random.seed(code_seed)
+    np.random.seed(data_seed)
+    timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    run_id = f"{config_seed}-{timestamp}"
+    print(
+        f"[doctor] deterministic seeds set (code={code_seed}, data={data_seed}, config={config_seed})"
+    )
+    print(f"[doctor] run-id template active -> {run_id}")
+
+
 def validate_env(env: Mapping[str, str] | None = None) -> None:
-    """Ensure required secrets are pulled from the environment."""
     if env is None:
         env = os.environ
     missing = [key for key in REQUIRED_ENV_KEYS if not env.get(key)]
     if missing:
-        raise EnvironmentError(f"Missing required environment variables: {', '.join(sorted(missing))}")
+        raise EnvironmentError(
+            f"Missing required environment variables: {', '.join(sorted(missing))}"
+        )
 
 
-_SECRET_ASSIGNMENT_PATTERNS = [re.compile(rf"{re.escape(key)}\s*=\s*['\"]") for key in REQUIRED_ENV_KEYS]
+_SECRET_ASSIGNMENT_PATTERNS = [
+    re.compile(rf"{re.escape(key)}\s*=\s*['\"]") for key in REQUIRED_ENV_KEYS
+]
 
 
 def check_secrets_not_hardcoded(base_path: Path = PACKAGE_DIR) -> None:
-    """Fail if any known secret appears to be hardcoded in Python modules."""
     for path in base_path.rglob("*.py"):
         text = path.read_text(encoding="utf-8")
         for pattern in _SECRET_ASSIGNMENT_PATTERNS:
@@ -101,49 +131,114 @@ def check_secrets_not_hardcoded(base_path: Path = PACKAGE_DIR) -> None:
                 raise RuntimeError(f"Potential hardcoded secret detected in {path}")
 
 
-def scan_feature_code_for_odds(feature_path: Path = FEATURE_DIR) -> None:
-    """Ensure odds provider domains are not referenced in feature engineering code."""
-    for path in feature_path.rglob("*.py"):
-        text = path.read_text(encoding="utf-8")
-        for domain in ODDS_DOMAINS:
-            if domain in text:
-                raise RuntimeError(f"Odds API domain '{domain}' found in {path}")
+def scan_code_for_odds(paths: Sequence[Path]) -> None:
+    for base_path in paths:
+        for path in base_path.rglob("*.py"):
+            text = path.read_text(encoding="utf-8")
+            for domain in ODDS_DOMAINS:
+                if domain in text:
+                    try:
+                        location = path.relative_to(REPO_ROOT)
+                    except ValueError:
+                        location = path
+                    raise RuntimeError(
+                        f"Odds API domain '{domain}' found in {location}"
+                    )
 
 
-def ensure_run_registry() -> None:
-    registry_path = REPO_ROOT / "staged" / "run_registry.log"
+def ensure_run_registry(staged_root: Path) -> None:
+    staged_root.mkdir(parents=True, exist_ok=True)
+    registry_path = staged_root / "run_registry.log"
     if not registry_path.exists():
         registry_path.touch()
-    print(f"[doctor] run registry available at {registry_path.relative_to(REPO_ROOT)}")
+    print(
+        f"[doctor] run registry available at {registry_path.relative_to(REPO_ROOT)}"
+    )
 
 
-def render_report(ci: bool, seed_hashes: Mapping[str, str], slo_config: Mapping[str, object]) -> None:
-    print("[doctor] seed digests:")
-    for name, digest in seed_hashes.items():
-        print(f"    - {name}: {digest}")
-    slo_records = [
-        SLORecord("etl", float(slo_config.get("etl_budget_seconds", 0))),
-        SLORecord("feature_build", float(slo_config.get("feature_budget_seconds", 0))),
-        SLORecord("training", float(slo_config.get("training_budget_seconds", 0))),
-        SLORecord("simulation", float(slo_config.get("simulation_budget_seconds", 0))),
-        SLORecord("reporting", float(slo_config.get("report_budget_seconds", 0))),
+def ensure_seed_policy(seeds: Mapping[str, object]) -> None:
+    required = {"code", "data", "config"}
+    missing = required - set(seeds)
+    if missing:
+        raise RuntimeError(
+            f"Seed policy incomplete; expected keys: {', '.join(sorted(required))}"
+        )
+    print(
+        "[doctor] seed policy confirmed with keys -> "
+        + ", ".join(sorted(seeds.keys()))
+    )
+
+
+def enforce_slos(slo_config: Mapping[str, object]) -> None:
+    records = [
+        SLORecord(
+            "etl",
+            float(slo_config.get("etl_seconds_per_season", 0)),
+            "seasonal ETL budget",
+        ),
+        SLORecord(
+            "feature_build",
+            float(slo_config.get("feature_build_seconds", 0)),
+            "feature engineering budget",
+        ),
+        SLORecord(
+            "baseline_train",
+            float(slo_config.get("baseline_train_seconds_per_season", 0)),
+            "forward-chaining baseline training budget",
+        ),
+        SLORecord(
+            "team_strength",
+            float(slo_config.get("team_strength_seconds", 0)),
+            "bayesian team strength budget",
+        ),
+        SLORecord(
+            "simulation_full_slate",
+            float(slo_config.get("simulation_full_slate_seconds", 0)),
+            "256-1024 sims per game budget",
+        ),
     ]
-    for record in slo_records:
+    for record in records:
         with SLOTimer(record):
             time.sleep(0.001)
-    if ci:
-        print("[doctor] running in CI mode: reduced logging enabled")
+
+
+def render_seed_hashes(hashes: Mapping[str, str]) -> None:
+    print("[doctor] seed digests:")
+    for name, digest in sorted(hashes.items()):
+        print(f"    - {name}: {digest}")
+
+
+def render_phase_matrix(phases: Sequence[object]) -> None:
+    items = ", ".join(str(phase) for phase in phases)
+    print(f"[doctor] phases prepared -> [{items}]")
 
 
 def run(ci: bool = False) -> None:
-    seeds = _load_yaml(CONFIG_DIR / "seeds.yaml")
-    slo_config = _load_yaml(CONFIG_DIR / "slo.yaml")
+    defaults = load_defaults()
+    seeds = defaults.get("seeds", {})
+    slo_config = defaults.get("slo", {})
+    project_meta = defaults.get("project", {})
+
+    ensure_seed_policy(seeds)
+    set_global_seeds(seeds)
     validate_env()
     check_secrets_not_hardcoded()
-    scan_feature_code_for_odds()
-    ensure_run_registry()
+    scan_code_for_odds([FEATURE_DIR, MODEL_DIR])
+
+    staged_root = REPO_ROOT / str(defaults.get("contracts", {}).get("staged_root", "staged"))
+    ensure_run_registry(staged_root)
+
     hashes = compute_seed_hashes(seeds)
-    render_report(ci, hashes, slo_config)
+    render_seed_hashes(hashes)
+    enforce_slos(slo_config)
+    render_phase_matrix(project_meta.get("phases", []))
+    template = project_meta.get("run_id_template")
+    if template:
+        print(f"[doctor] run-id structure -> {template}")
+
+    if ci:
+        print("[doctor] running in CI mode -> concise logging enabled")
+
     print("[doctor] all checks passed")
 
 

--- a/configs/defaults.yaml
+++ b/configs/defaults.yaml
@@ -1,0 +1,53 @@
+project:
+  name: A22A
+  phases: [1, 2, 3, 4, 5, 6]
+  run_id_template: "{season}-{phase}-run-{timestamp}"
+seeds:
+  code: 101
+  data: 202
+  config: 303
+slo:
+  etl_seconds_per_season: 300
+  feature_build_seconds: 120
+  baseline_train_seconds_per_season: 180
+  team_strength_seconds: 120
+  simulation_full_slate_seconds: 60
+contracts:
+  staged_root: "staged"
+  datasets:
+    team_games:
+      join_keys: ["season", "week", "game_id", "team_id"]
+      schema:
+        season: int64
+        week: int64
+        game_id: str
+        team_id: str
+    pbp:
+      join_keys: ["season", "week", "game_id"]
+      schema:
+        season: int64
+        week: int64
+        game_id: str
+    drives:
+      join_keys: ["season", "week", "game_id", "team_id"]
+      schema:
+        season: int64
+        week: int64
+        game_id: str
+        team_id: str
+feature_store:
+  leakage_guard_columns: ["game_id", "team_id", "season", "week", "target"]
+  psi_bins: 10
+models:
+  baseline:
+    cv_folds: 4
+    purging_weeks: 1
+  team_strength:
+    recency_decay: 0.85
+    min_games: 3
+simulation:
+  qmc_sampler: "sobol"
+  max_sims_per_game: 1024
+  early_stop_margin: 0.01
+reports:
+  weekly_template: "reports/weekly"

--- a/configs/seeds.yaml
+++ b/configs/seeds.yaml
@@ -1,3 +1,0 @@
-code_seed: code-placeholder
-data_seed: data-placeholder
-config_seed: config-placeholder

--- a/configs/slo.yaml
+++ b/configs/slo.yaml
@@ -1,5 +1,0 @@
-etl_budget_seconds: 300
-feature_budget_seconds: 120
-training_budget_seconds: 600
-simulation_budget_seconds: 180
-report_budget_seconds: 120

--- a/configs/team_strength.yaml
+++ b/configs/team_strength.yaml
@@ -1,2 +1,0 @@
-recency_decay: 0.85
-prior_scale: 1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,16 +8,11 @@ version = "0.1.0"
 description = "All-22 Atlas bootstrap scaffolding"
 authors = [{name = "All-22 Atlas"}]
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = "~=3.11"
 dependencies = [
     "pyyaml>=6.0",
     "polars>=0.20",
     "numpy>=1.24",
-    "pandas>=2.0",
-    "matplotlib>=3.7",
-    "lightgbm>=4.0",
-    "scikit-learn>=1.3",
-    "pyarrow>=14.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import polars as pl
 import pytest
 
+from a22a.data import contracts
 from a22a.tools import doctor
 
 
@@ -19,8 +21,31 @@ def test_check_secrets_not_hardcoded(tmp_path: Path):
         doctor.check_secrets_not_hardcoded(tmp_path)
 
 
-def test_scan_feature_code_for_odds(tmp_path: Path):
+def test_scan_code_for_odds(tmp_path: Path):
     feature = tmp_path / "feature.py"
     feature.write_text("# using theoddsapi.com", encoding="utf-8")
     with pytest.raises(RuntimeError):
-        doctor.scan_feature_code_for_odds(tmp_path)
+        doctor.scan_code_for_odds([tmp_path])
+
+
+def test_contract_join_key_validation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    cfg = tmp_path / "defaults.yaml"
+    cfg.write_text(
+        """
+contracts:
+  datasets:
+    sample:
+      join_keys: ["season", "week"]
+      schema:
+        season: int64
+        week: int64
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(contracts, "CONFIG_PATH", cfg)
+    monkeypatch.setattr(contracts, "REPO_ROOT", tmp_path)
+    frame = pl.DataFrame({"season": [2023], "week": [1]})
+    contracts.assert_contract("sample", frame)
+    bad = pl.DataFrame({"season": [2023]})
+    with pytest.raises(ValueError):
+        contracts.assert_contract("sample", bad)


### PR DESCRIPTION
## What changed / Why?
- Bootstrapped Phases 1–6 scaffolding with centralized defaults, Make targets, CI, and governance policy updates.
- Added data/feature/model/simulation stubs aligned with phase acceptance criteria plus unit coverage for env and contract guards.

## Doctor Output
```text
[doctor] seed policy confirmed with keys -> code, config, data
/workspace/All-22-Atlas-A22A-/a22a/tools/doctor.py:103: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
[doctor] deterministic seeds set (code=101, data=202, config=303)
[doctor] run-id template active -> 303-20251003125720
[doctor] run registry available at staged/run_registry.log
[doctor] seed digests:
    - code: 16dc368a89b4
    - config: 8bd9c0d45353
    - data: c17edaae86e4
[doctor] starting SLO window for etl (budget=300.0s :: seasonal ETL budget)
[doctor] completed etl in 0.0017s -> OK
[doctor] starting SLO window for feature_build (budget=120.0s :: feature engineering budget)
[doctor] completed feature_build in 0.0011s -> OK
[doctor] starting SLO window for baseline_train (budget=180.0s :: forward-chaining baseline training budget)
[doctor] completed baseline_train in 0.0011s -> OK
[doctor] starting SLO window for team_strength (budget=120.0s :: bayesian team strength budget)
[doctor] completed team_strength in 0.0011s -> OK
[doctor] starting SLO window for simulation_full_slate (budget=60.0s :: 256-1024 sims per game budget)
[doctor] completed simulation_full_slate in 0.0013s -> OK
[doctor] phases prepared -> [1, 2, 3, 4, 5, 6]
[doctor] run-id structure -> {season}-{phase}-run-{timestamp}
[doctor] all checks passed
```

## Acceptance Checkboxes (Phases 1–6)
[x] Phase 1 — Scaffolding & Governance: doctor < 30s; run registry + seed policy present
[x] Phase 2 — Data Spine: staged/ dir created; contracts module stub with schema and join-key assertions; ingest target no-ops cleanly without data
[x] Phase 3 — Feature Store v1: Polars lazy pipeline stubs + leakage guard + PSI hook; features target no-ops cleanly
[x] Phase 4 — Baseline Model: training stub with purged forward-chaining CV placeholder; calibration plot scaffold; no odds usage
[x] Phase 5 — Bayesian Team Strength: module stub with recency decay config; returns dummy θ table with CI fields
[x] Phase 6 — Simulation Engine v1: run.py sim stub with QMC/CI interfaces and early-stop hooks; emits fair ladder placeholders


------
https://chatgpt.com/codex/tasks/task_e_68dfc68b70388332a71cbef9e3a01a68