### PR TITLE
Implement Phase 7 decision engine and Phase 8 UER models

### DIFF
--- a/a22a/decision/portfolio.py
+++ b/a22a/decision/portfolio.py
@@ -1,39 +1,57 @@
-"""Phase 7 decision engine bootstrap stubs."""
+"""Phase 7 decision engine implementation.
+
+The decision engine ingests calibrated win probabilities produced upstream, Monte
+Carlo distribution summaries from the Phase 6 simulator, and bankroll settings
+from configuration.  Using those inputs it selects a portfolio of wagers and
+sizes stakes under a fractional Kelly framework with multiple exposure caps.
+
+The module intentionally keeps the data requirements light – helpers generate a
+small deterministic stub slate that mimics the shape of future integrations so
+tests can exercise the full flow without external dependencies.
+"""
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Iterable, Optional
 
+import numpy as np
 import pandas as pd
 import yaml
 
-from a22a.decision.selectivity import SelectivityConfig, apply_selectivity
+from a22a.decision.selectivity import SelectivityConfig, SelectionMode, apply_selectivity
+from a22a.metrics.selection import SelectionMetrics
 
 
 ARTIFACT_DIR = Path("artifacts/picks")
 ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
-ARTIFACT_FILE = ARTIFACT_DIR / "picks_week_stub.csv"
 
 
 @dataclass(frozen=True)
 class DecisionConfig:
+    """Configuration bundle for the decision engine."""
+
     k_top: int
     prob_threshold: float
+    selection_mode: SelectionMode
     kelly_fraction: float
     max_stake_pct_per_bet: float
     max_stake_pct_per_game: float
     max_weekly_exposure_pct: float
+    seed: int
 
     @classmethod
     def from_mapping(cls, data: dict[str, float]) -> "DecisionConfig":
         return cls(
             k_top=int(data.get("k_top", 5)),
             prob_threshold=float(data.get("prob_threshold", 0.6)),
+            selection_mode=SelectionMode(data.get("selection_mode", "hybrid")),
             kelly_fraction=float(data.get("kelly_fraction", 0.25)),
             max_stake_pct_per_bet=float(data.get("max_stake_pct_per_bet", 0.02)),
             max_stake_pct_per_game=float(data.get("max_stake_pct_per_game", 0.03)),
             max_weekly_exposure_pct=float(data.get("max_weekly_exposure_pct", 0.15)),
+            seed=int(data.get("seed", 42)),
         )
 
 
@@ -45,38 +63,111 @@ def _load_config(path: str | Path = "configs/defaults.yaml") -> dict:
 
 
 def _stub_candidates() -> pd.DataFrame:
-    """Create stub probability + outcome table (no odds usage)."""
+    """Create a deterministic stub slate used in tests.
 
-    return pd.DataFrame(
-        [
-            {"game_id": "GB@CHI", "market": "spread", "team": "CHI", "win_prob": 0.58, "actual": False},
-            {"game_id": "GB@CHI", "market": "spread", "team": "GB", "win_prob": 0.52, "actual": True},
-            {"game_id": "KC@DEN", "market": "moneyline", "team": "KC", "win_prob": 0.61, "actual": True},
-            {"game_id": "KC@DEN", "market": "moneyline", "team": "DEN", "win_prob": 0.39, "actual": False},
-            {"game_id": "SF@SEA", "market": "total_over", "team": "SF", "win_prob": 0.57, "actual": False},
-        ]
+    The stub includes the calibrated win probability, Phase 6 simulation moments,
+    and historical outcomes for a tiny evaluation slice.
+    """
+
+    rng = np.random.default_rng(202401)
+    slate = []
+    games = [
+        ("GB@CHI", "spread", ("CHI", 0.58, 2.4), ("GB", 0.42, -2.4)),
+        ("KC@DEN", "moneyline", ("KC", 0.64, 5.6), ("DEN", 0.36, -5.6)),
+        ("SF@SEA", "total_over", ("SF", 0.55, 3.1),),
+        ("DAL@PHI", "spread", ("DAL", 0.51, 0.8), ("PHI", 0.49, -0.8)),
+    ]
+    for game_id, market, *sides in games:
+        for side, prob, margin in sides:
+            slate.append(
+                {
+                    "game_id": game_id,
+                    "market": market,
+                    "side": side,
+                    "win_prob": prob,
+                    "sim_margin_mean": margin,
+                    "sim_margin_std": abs(margin) / 2 + 4,
+                    "sim_fair_prob": 0.5 + np.sign(margin) * min(0.1, abs(margin) / 10),
+                    "actual": bool(rng.uniform() < prob),
+                }
+            )
+    return pd.DataFrame(slate)
+
+
+def _stub_simulations(candidates: pd.DataFrame, *, draws: int = 256) -> pd.DataFrame:
+    """Create Phase 6-style simulation draws for correlation estimation."""
+
+    rng = np.random.default_rng(8675309)
+    samples = []
+    for game_id, group in candidates.groupby("game_id"):
+        mean = group["sim_margin_mean"].mean()
+        std = max(1.5, group["sim_margin_std"].mean())
+        draws_arr = rng.normal(loc=mean, scale=std, size=draws)
+        for idx, value in enumerate(draws_arr):
+            samples.append({"game_id": game_id, "sample_id": idx, "margin": float(value)})
+    return pd.DataFrame(samples)
+
+
+def _kelly_fraction(prob: float, *, fraction: float) -> float:
+    """Return the fractional Kelly stake for even odds."""
+
+    edge = max(0.0, 2 * prob - 1)
+    return edge * fraction
+
+
+def _confidence_signal(prob: float, sim_fair_prob: float, sim_margin_mean: float) -> float:
+    """Blend multiple confidence signals into a scalar rank value."""
+
+    prob_edge = abs(prob - 0.5)
+    sim_edge = abs(sim_fair_prob - 0.5)
+    margin_edge = abs(sim_margin_mean) / 10.0
+    return 0.6 * prob_edge + 0.3 * sim_edge + 0.1 * margin_edge
+
+
+def _rank_candidates(df: pd.DataFrame) -> pd.DataFrame:
+    ranked = df.copy()
+    ranked["confidence"] = ranked.apply(
+        lambda row: _confidence_signal(
+            row["win_prob"], row.get("sim_fair_prob", 0.5), row.get("sim_margin_mean", 0.0)
+        ),
+        axis=1,
     )
+    return ranked.sort_values(["confidence", "win_prob"], ascending=False).reset_index(drop=True)
 
 
-def _size_stakes(df: pd.DataFrame, selected_mask: list[bool], config: DecisionConfig, *, bankroll: float = 1.0) -> pd.DataFrame:
-    """Apply fractional Kelly sizing with exposure caps."""
+def _size_stakes(
+    df: pd.DataFrame,
+    selected_mask: list[bool],
+    config: DecisionConfig,
+    *,
+    bankroll: float = 1.0,
+    sim_draws: Optional[pd.DataFrame] = None,
+) -> pd.DataFrame:
+    """Apply fractional Kelly sizing with exposure caps and correlation guard."""
 
     sized = df.copy()
     sized["selected"] = selected_mask
     sized["stake_pct"] = 0.0
-    sized.loc[sized["selected"], "stake_pct"] = (
-        sized.loc[sized["selected"], "win_prob"].apply(lambda p: max(0.0, (2 * p) - 1))
-        * config.kelly_fraction
-    )
+
+    if sized["selected"].any():
+        sized.loc[sized["selected"], "stake_pct"] = sized.loc[sized["selected"], "win_prob"].apply(
+            lambda p: _kelly_fraction(p, fraction=config.kelly_fraction)
+        )
+
     sized["stake_pct"] = sized["stake_pct"].clip(upper=config.max_stake_pct_per_bet)
 
+    # Cap exposure per game (games may have multiple markets).
     for game_id, group in sized.groupby("game_id"):
         total = group["stake_pct"].sum()
         if total > config.max_stake_pct_per_game and total > 0:
             scale = config.max_stake_pct_per_game / total
             sized.loc[group.index, "stake_pct"] *= scale
 
-    total_weekly = sized["stake_pct"].sum()
+    # Correlation guard: downscale total exposure when simulations show high
+    # cross-game co-movement.
+    corr_guard = _correlation_multiplier(sized, sim_draws)
+
+    total_weekly = sized["stake_pct"].sum() * corr_guard
     if total_weekly > config.max_weekly_exposure_pct and total_weekly > 0:
         scale = config.max_weekly_exposure_pct / total_weekly
         sized["stake_pct"] *= scale
@@ -85,26 +176,117 @@ def _size_stakes(df: pd.DataFrame, selected_mask: list[bool], config: DecisionCo
     return sized
 
 
-def run(config_path: str | Path = "configs/defaults.yaml", *, candidates: Optional[pd.DataFrame] = None) -> pd.DataFrame:
+def _correlation_multiplier(df: pd.DataFrame, sim_draws: Optional[pd.DataFrame]) -> float:
+    """Return a multiplier >= 1 accounting for correlated exposure.
+
+    The multiplier is 1 + mean pairwise correlation of |margin| across the games
+    with active stakes.  Missing or degenerate simulations fall back to 1.
+    """
+
+    active_games = df.loc[df["stake_pct"] > 0, "game_id"].unique().tolist()
+    if not active_games or sim_draws is None or sim_draws.empty:
+        return 1.0
+
+    pivot = (
+        sim_draws[sim_draws["game_id"].isin(active_games)]
+        .assign(abs_margin=lambda d: d["margin"].abs())
+        .pivot_table(index="sample_id", columns="game_id", values="abs_margin")
+    )
+    if pivot.shape[1] < 2:
+        return 1.0
+
+    corr = pivot.corr(min_periods=10).replace([np.inf, -np.inf], np.nan).fillna(0.0)
+    if corr.empty:
+        return 1.0
+
+    # Average the off-diagonal correlations.
+    mask = ~np.eye(len(corr), dtype=bool)
+    if not mask.any():
+        return 1.0
+    mean_corr = float(np.nanmean(corr.to_numpy()[mask]))
+    return max(1.0, 1.0 + max(0.0, mean_corr))
+
+
+def _historical_metrics(
+    df_ranked: pd.DataFrame,
+    selected_mask: Iterable[bool],
+    k: int,
+) -> SelectionMetrics:
+    """Evaluate precision and coverage on the historical slice."""
+
+    selected_series = pd.Series(list(selected_mask))
+    ordered_actuals = df_ranked.loc[selected_series.to_numpy(), "actual"].tolist()
+    coverage = selected_series.mean() if len(selected_series) else 0.0
+    if not ordered_actuals:
+        return SelectionMetrics(precision_at_k=0.0, coverage=float(coverage), sample_size=len(df_ranked))
+    top_k = ordered_actuals[: min(k, len(ordered_actuals))]
+    precision = float(sum(top_k) / len(top_k)) if top_k else 0.0
+    return SelectionMetrics(precision_at_k=precision, coverage=float(coverage), sample_size=len(df_ranked))
+
+
+def _artifact_stem(stamp: Optional[str] = None) -> str:
+    stamp_val = stamp or datetime.now(timezone.utc).strftime("%Y%m%d")
+    return f"picks_week_{stamp_val}"
+
+
+def _write_artifacts(df: pd.DataFrame, stem: str) -> None:
+    csv_path = ARTIFACT_DIR / f"{stem}.csv"
+    json_path = ARTIFACT_DIR / f"{stem}.json"
+    df.to_csv(csv_path, index=False)
+    df.to_json(json_path, orient="records", indent=2)
+    print(f"[decision] picks written to {csv_path}")
+    print(f"[decision] picks written to {json_path}")
+
+
+def run(
+    config_path: str | Path = "configs/defaults.yaml",
+    *,
+    candidates: Optional[pd.DataFrame] = None,
+    sim_draws: Optional[pd.DataFrame] = None,
+    bankroll: float = 1.0,
+    stamp: Optional[str] = None,
+) -> pd.DataFrame:
     """Entry point used by ``make decision``."""
 
     raw = _load_config(config_path)
     decision_cfg = DecisionConfig.from_mapping(raw.get("decision", {}))
-    data = candidates.copy() if candidates is not None else _stub_candidates()
+
+    base = candidates.copy() if candidates is not None else _stub_candidates()
+    ranked = _rank_candidates(base)
+
+    np.random.default_rng(decision_cfg.seed)
 
     select_cfg = SelectivityConfig(
-        prob_threshold=decision_cfg.prob_threshold, k_top=decision_cfg.k_top
+        prob_threshold=decision_cfg.prob_threshold,
+        k_top=decision_cfg.k_top,
+        mode=decision_cfg.selection_mode,
     )
-    select_result = apply_selectivity(data, select_cfg)
-    sized = _size_stakes(data, select_result.selected_mask, decision_cfg)
+    select_result = apply_selectivity(ranked, select_cfg)
 
-    sized.to_csv(ARTIFACT_FILE, index=False)
+    if not any(select_result.selected_mask):
+        stem = _artifact_stem(stamp)
+        abstain_df = ranked.assign(selected=False, stake_pct=0.0, stake=0.0)
+        _write_artifacts(abstain_df, stem)
+        print(
+            f"[decision] precision@{decision_cfg.k_top}: 0.000 | coverage: 0.000 | exposure: 0.00% | abstained"
+        )
+        return abstain_df
 
-    print("[decision] picks written to", ARTIFACT_FILE)
+    draws = sim_draws if sim_draws is not None else _stub_simulations(ranked)
+    sized = _size_stakes(ranked, select_result.selected_mask, decision_cfg, bankroll=bankroll, sim_draws=draws)
+
+    metrics = _historical_metrics(ranked, select_result.selected_mask, decision_cfg.k_top)
+    exposure = sized["stake_pct"].sum()
+    abstentions = int(len(ranked) - sized["selected"].sum())
+
+    stem = _artifact_stem(stamp)
+    _write_artifacts(sized, stem)
+
     print(
-        f"[decision] precision@{decision_cfg.k_top}: {select_result.metrics.precision_at_k:.3f} | "
-        f"coverage: {select_result.metrics.coverage:.3f}"
+        f"[decision] precision@{decision_cfg.k_top}: {metrics.precision_at_k:.3f} | "
+        f"coverage: {metrics.coverage:.3f}"
     )
+    print(f"[decision] total exposure: {exposure:.2%} | abstentions: {abstentions}")
 
     return sized
 

--- a/a22a/decision/selectivity.py
+++ b/a22a/decision/selectivity.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import Iterable
 
 import pandas as pd
@@ -9,10 +10,19 @@ import pandas as pd
 from a22a.metrics.selection import SelectionMetrics, evaluate_selection
 
 
+class SelectionMode(str, Enum):
+    """Selection policy enum."""
+
+    TOP_K = "top_k"
+    THRESHOLD = "threshold"
+    HYBRID = "hybrid"
+
+
 @dataclass(frozen=True)
 class SelectivityConfig:
     prob_threshold: float
     k_top: int
+    mode: SelectionMode = SelectionMode.HYBRID
 
 
 @dataclass(frozen=True)
@@ -38,10 +48,16 @@ def _top_k_mask(probs: Iterable[float], k: int) -> list[bool]:
 
 
 def apply_selectivity(df: pd.DataFrame, config: SelectivityConfig, actual_col: str = "actual") -> SelectivityResult:
-    """Apply thresholding then top-K selection and compute metrics."""
+    """Apply configured selection policy and compute metrics."""
 
-    threshold_mask = _threshold_mask(df["win_prob"], config.prob_threshold)
-    topk_mask = _top_k_mask(df["win_prob"], config.k_top)
-    selected_mask = [th and tk for th, tk in zip(threshold_mask, topk_mask)]
+    if config.mode is SelectionMode.THRESHOLD:
+        selected_mask = _threshold_mask(df["win_prob"], config.prob_threshold)
+    elif config.mode is SelectionMode.TOP_K:
+        selected_mask = _top_k_mask(df["win_prob"], config.k_top)
+    else:
+        threshold_mask = _threshold_mask(df["win_prob"], config.prob_threshold)
+        topk_mask = _top_k_mask(df["win_prob"], config.k_top)
+        selected_mask = [th and tk for th, tk in zip(threshold_mask, topk_mask)]
+
     metrics = evaluate_selection(df[actual_col], selected_mask, k=config.k_top)
     return SelectivityResult(selected_mask=selected_mask, metrics=metrics)

--- a/a22a/units/uer.py
+++ b/a22a/units/uer.py
@@ -1,11 +1,19 @@
-"""Phase 8 Unit Effectiveness Ratings (UER) bootstrap stubs."""
+"""Phase 8 Unit Effectiveness Ratings (UER).
+
+The ratings approximate a ridge-regularised adjusted plus-minus system at the
+team-week level.  The implementation is intentionally light-weight while still
+showing the full set of modelling hooks expected later in the project: feature
+engineering (including TTT normalisation), opponent adjustments, recency
+shrinkage, and synergy scaffolds.
+"""
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+import numpy as np
 import pandas as pd
 import polars as pl
 import yaml
@@ -14,7 +22,6 @@ from a22a.units import synergy
 
 ARTIFACT_DIR = Path("artifacts/uer")
 ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
-ARTIFACT_FILE = ARTIFACT_DIR / "uer_week_stub.parquet"
 UER_AXES = ["off_pass", "off_rush", "def_pass", "def_rush"]
 
 
@@ -23,6 +30,7 @@ class UERConfig:
     recency_half_life_weeks: float
     ridge_lambda: float
     min_snaps_threshold: int
+    ttt_reference: float
 
     @classmethod
     def from_mapping(cls, data: dict[str, float]) -> "UERConfig":
@@ -30,6 +38,7 @@ class UERConfig:
             recency_half_life_weeks=float(data.get("recency_half_life_weeks", 6)),
             ridge_lambda=float(data.get("ridge_lambda", 10.0)),
             min_snaps_threshold=int(data.get("min_snaps_threshold", 50)),
+            ttt_reference=float(data.get("ttt_reference", 2.6)),
         )
 
 
@@ -41,19 +50,28 @@ def _load_config(path: str | Path = "configs/defaults.yaml") -> dict:
 
 
 def _toy_snap_log() -> pd.DataFrame:
-    """Create a toy RAPM-style snapshot table."""
+    """Create a deterministic toy snapshot table."""
 
+    rng = np.random.default_rng(2208)
     rows = []
-    for unit_id in ("TEAM_A_OFF", "TEAM_B_DEF"):
+    teams = ["TEAM_A", "TEAM_B", "TEAM_C", "TEAM_D"]
+    base_epa = {"off_pass": 0.15, "off_rush": 0.06, "def_pass": -0.10, "def_rush": -0.04}
+    base_success = {"off_pass": 0.53, "off_rush": 0.50, "def_pass": 0.45, "def_rush": 0.47}
+    for team in teams:
         for axis in UER_AXES:
             rows.append(
                 {
-                    "unit_id": unit_id,
+                    "unit_id": f"{team}_{axis}",
+                    "team": team,
                     "axis": axis,
-                    "value": 0.05 if "off" in axis else -0.03,
-                    "snaps": 60 if unit_id == "TEAM_A_OFF" else 45,
-                    "weeks_ago": 1 if unit_id == "TEAM_A_OFF" else 3,
-                    "opponent_strength": 0.01,
+                    "epa_per_play": base_epa[axis] + rng.normal(0, 0.02),
+                    "success_rate": base_success[axis] + rng.normal(0, 0.015),
+                    "ttt": 2.55 + rng.normal(0, 0.18),
+                    "opponent_epa_allowed": rng.normal(0, 0.015),
+                    "opponent_success_allowed": rng.normal(0, 0.02),
+                    "snaps": int(rng.integers(35, 75)),
+                    "weeks_ago": int(rng.integers(0, 8)),
+                    "injury_factor": rng.uniform(0.9, 1.05),
                 }
             )
     return pd.DataFrame(rows)
@@ -71,76 +89,179 @@ def _apply_recency_weights(df: pd.DataFrame, config: UERConfig) -> pd.DataFrame:
     return weighted
 
 
+def _feature_engineering(df: pd.DataFrame, config: UERConfig) -> pd.DataFrame:
+    engineered = df.copy()
+    engineered["success_delta"] = engineered.groupby("axis")["success_rate"].transform(
+        lambda s: s - s.mean()
+    )
+    engineered["epa_adj"] = engineered["epa_per_play"] - engineered["opponent_epa_allowed"]
+    engineered["success_adj"] = (
+        engineered["success_rate"] - engineered["opponent_success_allowed"]
+    )
+    engineered["injury_adj"] = engineered["injury_factor"].fillna(1.0)
+
+    engineered["base_value"] = 0.6 * engineered["epa_adj"] + 0.4 * engineered["success_adj"]
+
+    # Time-to-throw normalisation only affects passing axes.
+    pass_mask = engineered["axis"].isin(["off_pass", "def_pass"])
+    ttt_ref = config.ttt_reference
+    engineered.loc[pass_mask, "ttt_normalised"] = (
+        engineered.loc[pass_mask, "ttt"].fillna(ttt_ref) - ttt_ref
+    )
+    engineered.loc[~pass_mask, "ttt_normalised"] = 0.0
+    engineered.loc[pass_mask, "base_value"] -= 0.12 * engineered.loc[pass_mask, "ttt_normalised"]
+
+    # Defensive metrics are framed so negative EPA is good.
+    def_mask = engineered["axis"].str.startswith("def_")
+    engineered.loc[def_mask, "base_value"] *= -1
+
+    engineered["value"] = engineered["base_value"] * engineered["injury_adj"]
+    return engineered
+
+
 def _opponent_adjust(df: pd.DataFrame) -> pd.DataFrame:
-    """Simple opponent adjustment placeholder."""
+    """Apply opponent adjustments to the engineered value."""
 
     adjusted = df.copy()
-    adjusted["adjusted_value"] = adjusted["value"] - adjusted["opponent_strength"]
+    adjusted["adjusted_value"] = adjusted["value"]
     return adjusted
 
 
-def _ridge_shrink(mean: float, weight_sum: float, config: UERConfig) -> float:
-    denom = weight_sum + config.ridge_lambda
-    if denom == 0:
-        return 0.0
-    return mean * (weight_sum / denom)
+def _solve_ridge(axis_df: pd.DataFrame, config: UERConfig) -> dict[str, tuple[float, float, float]]:
+    if axis_df.empty:
+        return {}
 
+    units = axis_df["unit_id"].unique().tolist()
+    idx_map = {unit: i for i, unit in enumerate(units)}
+    n_obs = len(axis_df)
+    n_units = len(units)
 
-def _ci_half_width(snaps: int) -> float:
-    return 1.96 * (0.1 / math.sqrt(max(snaps, 1)))
+    X = np.zeros((n_obs, n_units))
+    y = axis_df["adjusted_value"].to_numpy()
+    w = axis_df["weight"].to_numpy()
+    snaps = axis_df.groupby("unit_id")["snaps"].sum().to_dict()
 
+    for row_idx, (_, row) in enumerate(axis_df.iterrows()):
+        X[row_idx, idx_map[row["unit_id"]]] = 1.0
 
-def _estimate_axis_rating(df: pd.DataFrame, config: UERConfig) -> tuple[float, float, float]:
-    if df.empty:
-        return 0.0, 0.0, 0.0
+    sqrt_w = np.sqrt(w)
+    Xw = X * sqrt_w[:, None]
+    yw = y * sqrt_w
 
-    weight_sum = df["weight"].sum()
-    weighted_mean = (df["adjusted_value"] * df["weight"]).sum() / max(weight_sum, 1e-6)
-    shrunk = _ridge_shrink(weighted_mean, weight_sum, config)
+    lhs = Xw.T @ Xw + config.ridge_lambda * np.eye(n_units)
+    rhs = Xw.T @ yw
+    try:
+        inv_lhs = np.linalg.inv(lhs)
+    except np.linalg.LinAlgError:
+        inv_lhs = np.linalg.pinv(lhs)
+    beta = inv_lhs @ rhs
 
-    total_snaps = int(df["snaps"].sum())
-    if total_snaps < config.min_snaps_threshold:
-        shrink_factor = total_snaps / max(config.min_snaps_threshold, 1)
-        shrunk *= shrink_factor
-    else:
-        shrink_factor = 1.0
+    residuals = y - X @ beta
+    dof = max(float(w.sum()) - n_units, 1.0)
+    sigma2 = float(np.dot(w * residuals, residuals) / dof)
+    cov = inv_lhs * sigma2
+    std_err = np.sqrt(np.clip(np.diag(cov), 0.0, None))
 
-    half_width = _ci_half_width(total_snaps) + (1 - shrink_factor) * 0.05
-    return shrunk, shrunk - half_width, shrunk + half_width
+    results: dict[str, tuple[float, float, float]] = {}
+    for unit, idx in idx_map.items():
+        total_snaps = snaps.get(unit, 0)
+        snap_factor = min(1.0, total_snaps / max(config.min_snaps_threshold, 1))
+        mean = float(beta[idx]) * snap_factor
+        half_width = 1.96 * std_err[idx]
+        if snap_factor < 1.0:
+            half_width *= 1.0 / max(snap_factor, 1e-3)
+        results[unit] = (mean, mean - half_width, mean + half_width)
+    return results
 
 
 def _compute_uer_table(df: pd.DataFrame, config: UERConfig) -> pd.DataFrame:
-    results = []
-    for unit_id, group in df.groupby("unit_id"):
-        row: dict[str, float | str | int] = {"unit_id": unit_id, "snaps": int(group["snaps"].sum())}
-        for axis in UER_AXES:
-            axis_group = group[group["axis"] == axis]
-            mean, ci_low, ci_high = _estimate_axis_rating(axis_group, config)
+    rows: dict[str, dict[str, float | str | int]] = {}
+    snap_totals = df.groupby("unit_id")["snaps"].sum().to_dict()
+    for axis in UER_AXES:
+        axis_df = df[df["axis"] == axis]
+        axis_results = _solve_ridge(axis_df, config)
+        for unit_id, stats in axis_results.items():
+            row = rows.setdefault(
+                unit_id,
+                {"unit_id": unit_id, "snaps": int(snap_totals.get(unit_id, 0))},
+            )
+            mean, ci_low, ci_high = stats
             row[f"{axis}_mean"] = mean
             row[f"{axis}_ci_low"] = ci_low
             row[f"{axis}_ci_high"] = ci_high
-        results.append(row)
-    return pd.DataFrame(results)
+    table = pd.DataFrame(rows.values())
+    for axis in UER_AXES:
+        mean_col = f"{axis}_mean"
+        low_col = f"{axis}_ci_low"
+        high_col = f"{axis}_ci_high"
+        if mean_col not in table.columns:
+            table[mean_col] = 0.0
+        if low_col not in table.columns:
+            table[low_col] = table[mean_col]
+        if high_col not in table.columns:
+            table[high_col] = table[mean_col]
+    return table
 
 
-def run(config_path: str | Path = "configs/defaults.yaml", *, snapshots: Optional[pd.DataFrame] = None) -> pl.DataFrame:
+def _artifact_path(stamp: Optional[str] = None) -> Path:
+    stem = stamp or datetime.now(timezone.utc).strftime("%Y%m%d")
+    return ARTIFACT_DIR / f"uer_week_{stem}.parquet"
+
+
+def _log_extremes(table: pl.DataFrame) -> None:
+    for axis in UER_AXES:
+        mean_col = f"{axis}_mean"
+        ci_low = f"{axis}_ci_low"
+        ci_high = f"{axis}_ci_high"
+        if mean_col not in table.columns:
+            continue
+        top = table.sort(mean_col, descending=True).head(5)
+        bottom = table.sort(mean_col, descending=False).head(5)
+        print(f"[uer] axis={axis} top 5:")
+        for row in top.iter_rows(named=True):
+            mean = row.get(mean_col)
+            low = row.get(ci_low)
+            high = row.get(ci_high)
+            if mean is None or low is None or high is None:
+                continue
+            print(f"  {row['unit_id']}: {mean:+.3f} ({low:+.3f}, {high:+.3f})")
+        print(f"[uer] axis={axis} bottom 5:")
+        for row in bottom.iter_rows(named=True):
+            mean = row.get(mean_col)
+            low = row.get(ci_low)
+            high = row.get(ci_high)
+            if mean is None or low is None or high is None:
+                continue
+            print(f"  {row['unit_id']}: {mean:+.3f} ({low:+.3f}, {high:+.3f})")
+
+
+def run(
+    config_path: str | Path = "configs/defaults.yaml",
+    *,
+    snapshots: Optional[pd.DataFrame] = None,
+    stamp: Optional[str] = None,
+) -> pl.DataFrame:
     """Entry point for ``make uer``."""
 
     raw = _load_config(config_path)
     uer_cfg = UERConfig.from_mapping(raw.get("uer", {}))
     base = snapshots.copy() if snapshots is not None else _toy_snap_log()
-    weighted = _apply_recency_weights(base, uer_cfg)
+    engineered = _feature_engineering(base, uer_cfg)
+    weighted = _apply_recency_weights(engineered, uer_cfg)
     adjusted = _opponent_adjust(weighted)
 
+    # Synergy scaffolds (placeholders for future integration but invoked here).
     synergy.offensive_line_qb_synergy()
     synergy.qb_wr_synergy()
     synergy.front_scheme_synergy()
 
     table_pd = _compute_uer_table(adjusted, uer_cfg)
     table_pl = pl.from_pandas(table_pd)
-    table_pl.write_parquet(ARTIFACT_FILE)
+    artifact_path = _artifact_path(stamp)
+    table_pl.write_parquet(artifact_path)
 
-    print("[uer] table written to", ARTIFACT_FILE)
+    _log_extremes(table_pl)
+    print("[uer] table written to", artifact_path)
     return table_pl
 
 

--- a/tests/test_decision.py
+++ b/tests/test_decision.py
@@ -1,18 +1,20 @@
+from textwrap import dedent
+
 import pandas as pd
 
-from a22a.decision.portfolio import DecisionConfig, _size_stakes
-from a22a.decision.selectivity import SelectivityConfig, apply_selectivity
+from a22a.decision.portfolio import DecisionConfig, _size_stakes, run
+from a22a.decision.selectivity import SelectivityConfig, SelectionMode, apply_selectivity
 
 
 def test_abstains_for_coinflip_probs():
     cfg = DecisionConfig.from_mapping({})
     df = pd.DataFrame(
         [
-            {"game_id": "A", "market": "spread", "team": "A", "win_prob": 0.51, "actual": False},
-            {"game_id": "B", "market": "ml", "team": "B", "win_prob": 0.49, "actual": True},
+            {"game_id": "A", "market": "spread", "side": "A", "win_prob": 0.51, "actual": False},
+            {"game_id": "B", "market": "ml", "side": "B", "win_prob": 0.49, "actual": True},
         ]
     )
-    select_cfg = SelectivityConfig(prob_threshold=cfg.prob_threshold, k_top=cfg.k_top)
+    select_cfg = SelectivityConfig(prob_threshold=cfg.prob_threshold, k_top=cfg.k_top, mode=SelectionMode.HYBRID)
     result = apply_selectivity(df, select_cfg)
     assert not any(result.selected_mask)
 
@@ -28,12 +30,12 @@ def test_exposure_caps_respected():
     })
     df = pd.DataFrame(
         [
-            {"game_id": "G1", "market": "spread", "team": "X", "win_prob": 0.70, "actual": True},
-            {"game_id": "G1", "market": "total", "team": "Y", "win_prob": 0.68, "actual": False},
-            {"game_id": "G2", "market": "ml", "team": "Z", "win_prob": 0.72, "actual": True},
+            {"game_id": "G1", "market": "spread", "side": "X", "win_prob": 0.70, "actual": True},
+            {"game_id": "G1", "market": "total", "side": "Y", "win_prob": 0.68, "actual": False},
+            {"game_id": "G2", "market": "ml", "side": "Z", "win_prob": 0.72, "actual": True},
         ]
     )
-    select_cfg = SelectivityConfig(prob_threshold=cfg.prob_threshold, k_top=cfg.k_top)
+    select_cfg = SelectivityConfig(prob_threshold=cfg.prob_threshold, k_top=cfg.k_top, mode=SelectionMode.HYBRID)
     result = apply_selectivity(df, select_cfg)
     sized = _size_stakes(df, result.selected_mask, cfg)
 
@@ -42,3 +44,118 @@ def test_exposure_caps_respected():
         assert group["stake_pct"].sum() <= cfg.max_stake_pct_per_game + 1e-9
     assert sized["stake_pct"].sum() <= cfg.max_weekly_exposure_pct + 1e-9
     assert sized.loc[~pd.Series(result.selected_mask), "stake_pct"].eq(0).all()
+
+
+def test_correlation_guard_rescales_exposure():
+    cfg = DecisionConfig.from_mapping(
+        {
+            "prob_threshold": 0.5,
+            "k_top": 3,
+            "kelly_fraction": 0.75,
+            "max_stake_pct_per_bet": 0.1,
+            "max_stake_pct_per_game": 0.2,
+            "max_weekly_exposure_pct": 0.12,
+            "selection_mode": "top_k",
+            "seed": 7,
+        }
+    )
+    df = pd.DataFrame(
+        [
+            {"game_id": "G1", "market": "ml", "side": "A", "win_prob": 0.72, "actual": True},
+            {"game_id": "G2", "market": "ml", "side": "B", "win_prob": 0.73, "actual": False},
+        ]
+    )
+    select_cfg = SelectivityConfig(prob_threshold=0.5, k_top=2, mode=SelectionMode.TOP_K)
+    selection = apply_selectivity(df, select_cfg)
+    draws = pd.DataFrame(
+        [
+            {"game_id": "G1", "sample_id": i, "margin": 5.0} for i in range(50)
+        ]
+        + [
+            {"game_id": "G2", "sample_id": i, "margin": 5.0} for i in range(50)
+        ]
+    )
+    sized = _size_stakes(df, selection.selected_mask, cfg, sim_draws=draws)
+    assert sized["stake_pct"].sum() <= cfg.max_weekly_exposure_pct + 1e-9
+
+
+def test_run_deterministic_with_seed(tmp_path):
+    candidates = pd.DataFrame(
+        [
+            {
+                "game_id": "HOU@TEN",
+                "market": "spread",
+                "side": "HOU",
+                "win_prob": 0.62,
+                "sim_margin_mean": 4.2,
+                "sim_margin_std": 5.1,
+                "sim_fair_prob": 0.61,
+                "actual": True,
+            },
+            {
+                "game_id": "HOU@TEN",
+                "market": "spread",
+                "side": "TEN",
+                "win_prob": 0.38,
+                "sim_margin_mean": -4.2,
+                "sim_margin_std": 5.1,
+                "sim_fair_prob": 0.39,
+                "actual": False,
+            },
+            {
+                "game_id": "MIA@BUF",
+                "market": "ml",
+                "side": "BUF",
+                "win_prob": 0.57,
+                "sim_margin_mean": 2.7,
+                "sim_margin_std": 4.4,
+                "sim_fair_prob": 0.58,
+                "actual": False,
+            },
+        ]
+    )
+    draws = pd.DataFrame(
+        [
+            {"game_id": "HOU@TEN", "sample_id": i, "margin": 4.0 + (i % 3)}
+            for i in range(64)
+        ]
+        + [
+            {"game_id": "MIA@BUF", "sample_id": i, "margin": 3.0 - (i % 2)}
+            for i in range(64)
+        ]
+    )
+
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        dedent(
+            """
+            decision:
+              prob_threshold: 0.55
+              k_top: 2
+              kelly_fraction: 0.4
+              max_stake_pct_per_bet: 0.08
+              max_stake_pct_per_game: 0.15
+              max_weekly_exposure_pct: 0.2
+              selection_mode: hybrid
+              seed: 123
+            """
+        ).strip()
+    )
+
+    first = run(
+        config_path=cfg_path,
+        candidates=candidates,
+        sim_draws=draws,
+        bankroll=100.0,
+        stamp="unit",
+    )
+    second = run(
+        config_path=cfg_path,
+        candidates=candidates,
+        sim_draws=draws,
+        bankroll=100.0,
+        stamp="unit",
+    )
+
+    pd.testing.assert_frame_equal(first, second)
+

--- a/tests/test_uer.py
+++ b/tests/test_uer.py
@@ -18,10 +18,14 @@ def test_uer_handles_thin_samples():
             {
                 "unit_id": "THIN_UNIT",
                 "axis": axis,
-                "value": 0.02,
+                "epa_per_play": 0.02,
+                "success_rate": 0.48,
+                "ttt": 2.6,
+                "opponent_epa_allowed": 0.0,
+                "opponent_success_allowed": 0.47,
                 "snaps": 5,
                 "weeks_ago": 1,
-                "opponent_strength": 0.0,
+                "injury_factor": 1.0,
             }
             for axis in UER_AXES
         ]


### PR DESCRIPTION
## Summary
- implement decision engine with ranking, selection modes, Kelly sizing caps, correlation-aware exposure, and pick artifacts
- build ridge-regularised UER pipeline with feature engineering, recency weighting, CIs, and synergy logging
- expand decision and UER unit tests for abstention, cap, determinism, and thin sample coverage

## Testing
- pytest
- make doctor
- make uer
- make decision

------
https://chatgpt.com/codex/tasks/task_e_68e50b9977908332aefe9ae121ec6685