### PR TITLE
Add robust Polars to pandas converter

### DIFF
--- a/a22a/context/game_state.py
+++ b/a22a/context/game_state.py
@@ -18,6 +18,7 @@ import polars as pl
 import yaml
 
 from a22a.data import sample_data
+from a22a.utils.pandas_compat import to_pandas_safe
 
 CONFIG_PATH = pathlib.Path("configs/defaults.yaml")
 PARTIAL_SIM_KEYS = {
@@ -72,10 +73,7 @@ def _load_table(root: pathlib.Path, name: str) -> pl.DataFrame:
 
 
 def _polars_to_pandas(frame: pl.DataFrame) -> pd.DataFrame:
-    try:
-        return frame.to_pandas(use_pyarrow_extension_array=True).convert_dtypes()
-    except ModuleNotFoundError:
-        return pd.DataFrame(frame.to_dicts()).convert_dtypes()
+    return to_pandas_safe(frame)
 
 
 # ---------------------------------------------------------------------------

--- a/a22a/strategy/coach_adapt.py
+++ b/a22a/strategy/coach_adapt.py
@@ -37,6 +37,7 @@ from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.preprocessing import StandardScaler
 
 from a22a.data import sample_data
+from a22a.utils.pandas_compat import to_pandas_safe
 
 CONFIG_PATH = pathlib.Path("configs/defaults.yaml")
 
@@ -78,10 +79,7 @@ def _load_table(root: pathlib.Path, name: str) -> pl.DataFrame:
 
 
 def _polars_to_pandas(df: pl.DataFrame) -> pd.DataFrame:
-    try:
-        return df.to_pandas(use_pyarrow_extension_array=True).convert_dtypes()
-    except ModuleNotFoundError:
-        return pd.DataFrame(df.to_dicts()).convert_dtypes()
+    return to_pandas_safe(df)
 
 
 def _coach_lookup(games: pd.DataFrame) -> Dict[Tuple[str, str], str]:

--- a/a22a/utils/pandas_compat.py
+++ b/a22a/utils/pandas_compat.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+if TYPE_CHECKING:  # pragma: no cover - import only for typing
+    import polars as pl
+
+
+def to_pandas_safe(df_pl: "pl.DataFrame") -> pd.DataFrame:
+    """
+    Convert a Polars DataFrame to pandas with a robust dtype strategy.
+    1) Prefer Arrow extension arrays (fast & safe for timestamps)
+    2) Fallback to plain pandas dtypes if Arrow is unavailable
+    Returns: pandas.DataFrame
+    """
+    # Step 1: try Polars' Arrow-backed conversion if available
+    try:
+        pdf = df_pl.to_pandas(use_pyarrow_extension_array=True)  # polars>=0.20
+    except Exception:
+        try:
+            pdf = df_pl.to_pandas()
+        except Exception:
+            pdf = pd.DataFrame(df_pl.to_dicts())
+
+    # Step 2: normalize dtypes
+    try:
+        # If pyarrow + ArrowDtype is present, this will succeed
+        return pdf.convert_dtypes(dtype_backend="pyarrow")
+    except Exception:
+        # Fallback that works everywhere
+        return pdf.convert_dtypes(dtype_backend="numpy_nullable")
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "pandas>=2.2",
   "polars>=1.6",
   "duckdb>=1.0",
+  "pyarrow>=14,<19",
   "scikit-learn>=1.5",
   "lightgbm>=4.3",
   "catboost>=1.2",

--- a/tests/test_pandas_compat.py
+++ b/tests/test_pandas_compat.py
@@ -1,0 +1,11 @@
+import polars as pl
+
+from a22a.utils.pandas_compat import to_pandas_safe
+
+
+def test_to_pandas_safe_roundtrip():
+    df_pl = pl.DataFrame({"ts": [0, 1, 2], "s": ["a", "b", "c"]})
+    df_pd = to_pandas_safe(df_pl)
+
+    assert list(df_pd.columns) == ["ts", "s"]
+    assert len(df_pd) == 3


### PR DESCRIPTION
## Summary
- add a shared to_pandas_safe helper that falls back when PyArrow is unavailable
- switch the context and strategy pipelines to use the shared converter
- declare the PyArrow dependency and add a regression test for the converter

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e5742ed5b48332a66fd5fb65c13c07