### PR TITLE
Implement Phase 11 injury modeling and Phase 12 roster depth replacements

### DIFF
--- a/a22a/health/injury_model.py
+++ b/a22a/health/injury_model.py
@@ -1,68 +1,733 @@
-"""Bootstrap scaffolding for injury availability and exit risk modeling."""
+"""Phase 11 — injury availability and in-game exit risk modelling."""
 
 from __future__ import annotations
 
+import math
 import pathlib
 import time
-from typing import Dict, Iterable
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping
 
 import numpy as np
 import pandas as pd
 import yaml
+from sklearn.linear_model import LinearRegression, LogisticRegression
 
 CONFIG_PATH = pathlib.Path("configs/defaults.yaml")
 ARTIFACT_DIR = pathlib.Path("artifacts/health")
 
 
-def load_health_config() -> Dict[str, object]:
-    """Load the health configuration block from the defaults file."""
-    if not CONFIG_PATH.exists():
-        raise FileNotFoundError(f"missing config file: {CONFIG_PATH}")
-    config = yaml.safe_load(CONFIG_PATH.read_text()) or {}
-    return config.get("health", {})
+@dataclass(frozen=True)
+class HealthConfig:
+    """Configuration parameters for the health module."""
+
+    half_life_weeks: float = 8.0
+    min_events: int = 50
+    use_frailty: bool = True
+    seed: int = 0
+
+    @classmethod
+    def from_config(cls, config: Mapping[str, Any]) -> "HealthConfig":
+        raw = dict(config or {})
+        seed = int(raw.get("seed", 0))
+        health = raw.get("health", {}) or {}
+        return cls(
+            half_life_weeks=float(health.get("recency_half_life_weeks", 8)),
+            min_events=int(health.get("min_events", 50)),
+            use_frailty=bool(health.get("frailty", True)),
+            seed=seed,
+        )
 
 
-def build_player_pool(num_players: int = 256) -> Iterable[str]:
-    """Return a deterministic list of player identifiers for stub generation."""
-    return [f"P{i:05d}" for i in range(num_players)]
+def _load_config(path: pathlib.Path = CONFIG_PATH) -> Mapping[str, Any]:
+    if not path.exists():
+        return {}
+    return yaml.safe_load(path.read_text()) or {}
 
 
-def simulate_availability(players: Iterable[str], rng: np.random.Generator) -> pd.DataFrame:
-    """Produce a table of player availability probabilities bounded to [0, 1]."""
-    players = list(players)
-    availability = rng.uniform(0.72, 0.97, size=len(players))
-    df = pd.DataFrame(
+def _staged_root(cfg: Mapping[str, Any]) -> pathlib.Path:
+    paths = cfg.get("paths", {}) if isinstance(cfg, Mapping) else {}
+    return pathlib.Path(paths.get("staged", "./data/staged"))
+
+
+# ---------------------------------------------------------------------------
+# Sample data scaffolding (used when staged data absent)
+# ---------------------------------------------------------------------------
+
+
+def _sample_injury_reports() -> pd.DataFrame:
+    """Create a deterministic mini injury log spanning multiple weeks."""
+
+    rows: list[dict[str, Any]] = [
+        # Week 1 entries
         {
-            "player_id": players,
-            "season": 2024,
+            "season": 2023,
             "week": 1,
-            "avail_prob": np.clip(availability, 0.0, 1.0),
-            "source": "bootstrap_stub",
-        }
-    )
-    return df
-
-
-def simulate_exit_hazards(players: Iterable[str], rng: np.random.Generator) -> pd.DataFrame:
-    """Generate in-game exit hazard percentages that are guaranteed to be non-negative."""
-    players = list(players)
-    baseline = rng.uniform(0.3, 4.2, size=len(players))
-    df = pd.DataFrame(
+            "team_id": "BUF",
+            "player_id": "BUF_QB1",
+            "age": 28,
+            "position": "QB",
+            "practice_status": "full",
+            "game_status": "active",
+            "historical_snaps": 1100,
+            "snaps_played": 64,
+            "days_rest": 7,
+            "surface": "turf",
+            "weather_temp_f": 35,
+            "injury_start_week": 1,
+            "injury_id": "shoulder-2023",
+            "exit_events": 0,
+            "exit_exposure": 64,
+        },
         {
-            "player_id": players,
-            "season": 2024,
+            "season": 2023,
             "week": 1,
-            "exit_hazard_pct": np.maximum(baseline, 0.0),
-            "events_considered": rng.integers(10, 50, size=len(players)),
-        }
+            "team_id": "BUF",
+            "player_id": "BUF_WR1",
+            "age": 30,
+            "position": "WR",
+            "practice_status": "limited",
+            "game_status": "active",
+            "historical_snaps": 780,
+            "snaps_played": 52,
+            "days_rest": 7,
+            "surface": "turf",
+            "weather_temp_f": 35,
+            "injury_start_week": 1,
+            "injury_id": "knee-2023",
+            "exit_events": 0,
+            "exit_exposure": 52,
+        },
+        {
+            "season": 2023,
+            "week": 1,
+            "team_id": "BUF",
+            "player_id": "BUF_RB1",
+            "age": 25,
+            "position": "RB",
+            "practice_status": "limited",
+            "game_status": "active",
+            "historical_snaps": 610,
+            "snaps_played": 46,
+            "days_rest": 7,
+            "surface": "turf",
+            "weather_temp_f": 35,
+            "injury_start_week": 1,
+            "injury_id": "ankle-2023",
+            "exit_events": 0,
+            "exit_exposure": 46,
+        },
+        {
+            "season": 2023,
+            "week": 1,
+            "team_id": "KC",
+            "player_id": "KC_QB1",
+            "age": 29,
+            "position": "QB",
+            "practice_status": "limited",
+            "game_status": "active",
+            "historical_snaps": 1180,
+            "snaps_played": 66,
+            "days_rest": 7,
+            "surface": "grass",
+            "weather_temp_f": 37,
+            "injury_start_week": 1,
+            "injury_id": "ankle-2023",
+            "exit_events": 0,
+            "exit_exposure": 66,
+        },
+        {
+            "season": 2023,
+            "week": 1,
+            "team_id": "KC",
+            "player_id": "KC_WR1",
+            "age": 31,
+            "position": "WR",
+            "practice_status": "dnp",
+            "game_status": "out",
+            "historical_snaps": 800,
+            "snaps_played": 0,
+            "days_rest": 7,
+            "surface": "grass",
+            "weather_temp_f": 37,
+            "injury_start_week": 1,
+            "injury_id": "hamstring-2023",
+            "exit_events": 0,
+            "exit_exposure": 0,
+        },
+        {
+            "season": 2023,
+            "week": 1,
+            "team_id": "KC",
+            "player_id": "KC_TE1",
+            "age": 33,
+            "position": "TE",
+            "practice_status": "limited",
+            "game_status": "active",
+            "historical_snaps": 720,
+            "snaps_played": 49,
+            "days_rest": 7,
+            "surface": "grass",
+            "weather_temp_f": 37,
+            "injury_start_week": 1,
+            "injury_id": "knee-2023",
+            "exit_events": 0,
+            "exit_exposure": 49,
+        },
+        {
+            "season": 2023,
+            "week": 1,
+            "team_id": "KC",
+            "player_id": "KC_RB1",
+            "age": 27,
+            "position": "RB",
+            "practice_status": "full",
+            "game_status": "active",
+            "historical_snaps": 590,
+            "snaps_played": 43,
+            "days_rest": 7,
+            "surface": "grass",
+            "weather_temp_f": 37,
+            "injury_start_week": 1,
+            "injury_id": "shoulder-2023",
+            "exit_events": 0,
+            "exit_exposure": 43,
+        },
+        # Week 2
+        {
+            "season": 2023,
+            "week": 2,
+            "team_id": "BUF",
+            "player_id": "BUF_QB1",
+            "age": 28,
+            "position": "QB",
+            "practice_status": "limited",
+            "game_status": "active",
+            "historical_snaps": 1165,
+            "snaps_played": 63,
+            "days_rest": 4,
+            "surface": "turf",
+            "weather_temp_f": 38,
+            "injury_start_week": 1,
+            "injury_id": "shoulder-2023",
+            "exit_events": 0,
+            "exit_exposure": 63,
+        },
+        {
+            "season": 2023,
+            "week": 2,
+            "team_id": "BUF",
+            "player_id": "BUF_WR1",
+            "age": 30,
+            "position": "WR",
+            "practice_status": "limited",
+            "game_status": "questionable",
+            "historical_snaps": 832,
+            "snaps_played": 47,
+            "days_rest": 4,
+            "surface": "turf",
+            "weather_temp_f": 38,
+            "injury_start_week": 1,
+            "injury_id": "knee-2023",
+            "exit_events": 1,
+            "exit_exposure": 47,
+        },
+        {
+            "season": 2023,
+            "week": 2,
+            "team_id": "BUF",
+            "player_id": "BUF_RB1",
+            "age": 25,
+            "position": "RB",
+            "practice_status": "full",
+            "game_status": "active",
+            "historical_snaps": 668,
+            "snaps_played": 44,
+            "days_rest": 7,
+            "surface": "turf",
+            "weather_temp_f": 38,
+            "injury_start_week": 1,
+            "injury_id": "ankle-2023",
+            "exit_events": 0,
+            "exit_exposure": 44,
+        },
+        {
+            "season": 2023,
+            "week": 2,
+            "team_id": "KC",
+            "player_id": "KC_QB1",
+            "age": 29,
+            "position": "QB",
+            "practice_status": "limited",
+            "game_status": "active",
+            "historical_snaps": 1248,
+            "snaps_played": 64,
+            "days_rest": 4,
+            "surface": "grass",
+            "weather_temp_f": 41,
+            "injury_start_week": 1,
+            "injury_id": "ankle-2023",
+            "exit_events": 0,
+            "exit_exposure": 64,
+        },
+        {
+            "season": 2023,
+            "week": 2,
+            "team_id": "KC",
+            "player_id": "KC_WR1",
+            "age": 31,
+            "position": "WR",
+            "practice_status": "dnp",
+            "game_status": "out",
+            "historical_snaps": 800,
+            "snaps_played": 0,
+            "days_rest": 4,
+            "surface": "grass",
+            "weather_temp_f": 41,
+            "injury_start_week": 1,
+            "injury_id": "hamstring-2023",
+            "exit_events": 0,
+            "exit_exposure": 0,
+        },
+        {
+            "season": 2023,
+            "week": 2,
+            "team_id": "KC",
+            "player_id": "KC_TE1",
+            "age": 33,
+            "position": "TE",
+            "practice_status": "limited",
+            "game_status": "active",
+            "historical_snaps": 768,
+            "snaps_played": 45,
+            "days_rest": 4,
+            "surface": "grass",
+            "weather_temp_f": 41,
+            "injury_start_week": 1,
+            "injury_id": "knee-2023",
+            "exit_events": 1,
+            "exit_exposure": 45,
+        },
+        {
+            "season": 2023,
+            "week": 2,
+            "team_id": "KC",
+            "player_id": "KC_RB1",
+            "age": 27,
+            "position": "RB",
+            "practice_status": "limited",
+            "game_status": "active",
+            "historical_snaps": 640,
+            "snaps_played": 41,
+            "days_rest": 7,
+            "surface": "grass",
+            "weather_temp_f": 41,
+            "injury_start_week": 1,
+            "injury_id": "shoulder-2023",
+            "exit_events": 0,
+            "exit_exposure": 41,
+        },
+        # Week 3 (holdout for hazard)
+        {
+            "season": 2023,
+            "week": 3,
+            "team_id": "BUF",
+            "player_id": "BUF_QB1",
+            "age": 28,
+            "position": "QB",
+            "practice_status": "full",
+            "game_status": "active",
+            "historical_snaps": 1230,
+            "snaps_played": 68,
+            "days_rest": 7,
+            "surface": "turf",
+            "weather_temp_f": 45,
+            "injury_start_week": 1,
+            "injury_id": "shoulder-2023",
+            "exit_events": 0,
+            "exit_exposure": 68,
+        },
+        {
+            "season": 2023,
+            "week": 3,
+            "team_id": "BUF",
+            "player_id": "BUF_WR1",
+            "age": 30,
+            "position": "WR",
+            "practice_status": "limited",
+            "game_status": "questionable",
+            "historical_snaps": 884,
+            "snaps_played": 44,
+            "days_rest": 4,
+            "surface": "turf",
+            "weather_temp_f": 45,
+            "injury_start_week": 2,
+            "injury_id": "knee-2023-recur",
+            "exit_events": 1,
+            "exit_exposure": 44,
+        },
+        {
+            "season": 2023,
+            "week": 3,
+            "team_id": "BUF",
+            "player_id": "BUF_RB1",
+            "age": 25,
+            "position": "RB",
+            "practice_status": "full",
+            "game_status": "active",
+            "historical_snaps": 714,
+            "snaps_played": 45,
+            "days_rest": 7,
+            "surface": "turf",
+            "weather_temp_f": 45,
+            "injury_start_week": 1,
+            "injury_id": "ankle-2023",
+            "exit_events": 0,
+            "exit_exposure": 45,
+        },
+        {
+            "season": 2023,
+            "week": 3,
+            "team_id": "KC",
+            "player_id": "KC_QB1",
+            "age": 29,
+            "position": "QB",
+            "practice_status": "limited",
+            "game_status": "active",
+            "historical_snaps": 1312,
+            "snaps_played": 63,
+            "days_rest": 4,
+            "surface": "grass",
+            "weather_temp_f": 48,
+            "injury_start_week": 1,
+            "injury_id": "ankle-2023",
+            "exit_events": 0,
+            "exit_exposure": 63,
+        },
+        {
+            "season": 2023,
+            "week": 3,
+            "team_id": "KC",
+            "player_id": "KC_WR1",
+            "age": 31,
+            "position": "WR",
+            "practice_status": "limited",
+            "game_status": "active",
+            "historical_snaps": 854,
+            "snaps_played": 42,
+            "days_rest": 4,
+            "surface": "grass",
+            "weather_temp_f": 48,
+            "injury_start_week": 1,
+            "injury_id": "hamstring-2023",
+            "exit_events": 1,
+            "exit_exposure": 42,
+        },
+        {
+            "season": 2023,
+            "week": 3,
+            "team_id": "KC",
+            "player_id": "KC_TE1",
+            "age": 33,
+            "position": "TE",
+            "practice_status": "limited",
+            "game_status": "active",
+            "historical_snaps": 816,
+            "snaps_played": 44,
+            "days_rest": 7,
+            "surface": "grass",
+            "weather_temp_f": 48,
+            "injury_start_week": 1,
+            "injury_id": "knee-2023",
+            "exit_events": 0,
+            "exit_exposure": 44,
+        },
+        {
+            "season": 2023,
+            "week": 3,
+            "team_id": "KC",
+            "player_id": "KC_RB1",
+            "age": 27,
+            "position": "RB",
+            "practice_status": "full",
+            "game_status": "active",
+            "historical_snaps": 686,
+            "snaps_played": 40,
+            "days_rest": 7,
+            "surface": "grass",
+            "weather_temp_f": 48,
+            "injury_start_week": 1,
+            "injury_id": "shoulder-2023",
+            "exit_events": 0,
+            "exit_exposure": 40,
+        },
+    ]
+    return pd.DataFrame(rows)
+
+
+def _list_parquet(root: pathlib.Path, folder: str) -> list[pathlib.Path]:
+    target = root / folder
+    if not target.exists():
+        return []
+    return sorted(target.rglob("*.parquet"))
+
+
+def _load_injury_reports(cfg: Mapping[str, Any]) -> pd.DataFrame:
+    staged_root = _staged_root(cfg)
+    candidates = _list_parquet(staged_root, "injuries")
+    frames: list[pd.DataFrame] = []
+    for path in candidates:
+        try:
+            frames.append(pd.read_parquet(path))
+        except Exception:
+            continue
+    if frames:
+        combined = pd.concat(frames, ignore_index=True)
+        if not combined.empty:
+            return combined
+    return _sample_injury_reports()
+
+
+# ---------------------------------------------------------------------------
+# Feature engineering and modelling utilities
+# ---------------------------------------------------------------------------
+
+
+def _recency_weight(week: int, max_week: int, half_life: float) -> float:
+    decay = (max_week - week) / max(half_life, 1e-6)
+    return float(0.5 ** decay)
+
+
+def _compute_team_frailty(df: pd.DataFrame) -> pd.Series:
+    ordered = df.sort_values(["team_id", "season", "week"])  # copy not needed
+    def _expanding_mean(series: pd.Series) -> pd.Series:
+        return series.shift(1).expanding().mean()
+
+    baseline = ordered.groupby("team_id")["is_active"].apply(_expanding_mean)
+    if isinstance(baseline.index, pd.MultiIndex):
+        baseline.index = baseline.index.get_level_values(-1)
+    baseline = baseline.reindex(df.index)
+    global_mean = df["is_active"].mean()
+    baseline = baseline.fillna(global_mean if not math.isnan(global_mean) else 0.5)
+    odds = np.clip(baseline, 1e-3, 1 - 1e-3) / (1 - np.clip(baseline, 1e-3, 1 - 1e-3))
+    return np.log(odds)
+
+
+def _prepare_dataset(raw: pd.DataFrame, config: HealthConfig) -> pd.DataFrame:
+    frame = raw.copy()
+    if frame.empty:
+        raise ValueError("injury report table is empty")
+
+    frame["practice_status"] = frame["practice_status"].str.lower()
+    frame["game_status"] = frame["game_status"].str.lower()
+    frame["position"] = frame["position"].str.upper()
+    frame["surface"] = frame["surface"].str.lower()
+
+    active_states = {"active", "questionable", "probable"}
+    frame["is_active"] = frame["game_status"].isin(active_states).astype(int)
+
+    practice_map = {"full": 0.0, "limited": 1.0, "dnp": 2.0}
+    frame["practice_intensity"] = frame["practice_status"].map(practice_map).fillna(1.0)
+
+    frame["days_rest"] = frame["days_rest"].fillna(7).astype(float)
+    frame["short_week"] = (frame["days_rest"] < 6).astype(int)
+
+    frame["historical_snaps"] = frame["historical_snaps"].fillna(frame.get("snaps_played", 0)).astype(float)
+    frame["snaps_played"] = frame.get("snaps_played", 0).fillna(0).astype(float)
+    frame["exit_exposure"] = frame.get("exit_exposure", frame["snaps_played"]).fillna(0).astype(float)
+    frame["exit_events"] = frame.get("exit_events", 0).fillna(0).astype(float)
+
+    frame["injury_start_week"] = frame.get("injury_start_week", frame["week"]).fillna(frame["week"]).astype(int)
+    frame["time_since_injury_weeks"] = (
+        frame["week"].astype(int) - frame["injury_start_week"].astype(int)
+    ).clip(lower=0)
+
+    if "injury_id" in frame.columns:
+        frame["recurrence_flag"] = frame.groupby("player_id")["injury_id"].transform(
+            lambda s: s.duplicated().astype(int)
+        )
+    else:
+        frame["recurrence_flag"] = 0
+
+    max_week = frame["week"].max()
+    frame["recency_weight"] = frame["week"].apply(
+        lambda w: _recency_weight(int(w), int(max_week), config.half_life_weeks)
     )
-    return df
+
+    if config.use_frailty:
+        frame["team_frailty"] = _compute_team_frailty(frame)
+    else:
+        frame["team_frailty"] = 0.0
+
+    frame["weather_temp_f"] = frame.get("weather_temp_f", 55).fillna(55).astype(float)
+    return frame
 
 
-def write_artifact(df: pd.DataFrame, prefix: str, timestamp: str) -> pathlib.Path:
-    """Persist the dataframe to parquet with a CSV fallback."""
+def _availability_feature_matrix(frame: pd.DataFrame) -> pd.DataFrame:
+    numeric_cols = [
+        "age",
+        "practice_intensity",
+        "short_week",
+        "time_since_injury_weeks",
+        "recurrence_flag",
+        "team_frailty",
+        "historical_snaps",
+        "days_rest",
+    ]
+    base = frame[numeric_cols].astype(float)
+    pos_dummies = pd.get_dummies(frame["position"], prefix="pos")
+    surface_dummies = pd.get_dummies(frame["surface"], prefix="surface")
+    return pd.concat([base, pos_dummies, surface_dummies], axis=1)
+
+
+def _calibration_metrics(y_true: np.ndarray, y_prob: np.ndarray, bins: int = 8) -> Dict[str, float]:
+    brier = float(np.mean((y_true - y_prob) ** 2))
+    edges = np.linspace(0.0, 1.0, bins + 1)
+    ece = 0.0
+    total = len(y_prob)
+    for idx in range(bins):
+        left, right = edges[idx], edges[idx + 1]
+        if idx == bins - 1:
+            mask = (y_prob >= left) & (y_prob <= right)
+        else:
+            mask = (y_prob >= left) & (y_prob < right)
+        if not np.any(mask):
+            continue
+        avg_true = float(np.mean(y_true[mask]))
+        avg_prob = float(np.mean(y_prob[mask]))
+        ece += (mask.sum() / total) * abs(avg_true - avg_prob)
+    return {"brier": brier, "ece": float(ece)}
+
+
+def _fit_availability(frame: pd.DataFrame, config: HealthConfig) -> tuple[pd.DataFrame, pd.DataFrame, Dict[str, float]]:
+    features = _availability_feature_matrix(frame)
+    y = frame["is_active"].astype(int).to_numpy()
+    weights = frame["recency_weight"].to_numpy()
+
+    model = LogisticRegression(max_iter=500, solver="lbfgs", random_state=config.seed)
+    model.fit(features, y, sample_weight=weights)
+
+    probs = model.predict_proba(features)[:, 1]
+    probs = np.clip(probs, 1e-6, 1 - 1e-6)
+    frame = frame.copy()
+    frame["avail_prob"] = probs
+
+    metrics = _calibration_metrics(y, probs)
+
+    latest_mask = frame.groupby("player_id")["week"].transform("max") == frame["week"]
+    availability = frame.loc[
+        latest_mask,
+        [
+            "player_id",
+            "team_id",
+            "season",
+            "week",
+            "avail_prob",
+            "age",
+            "position",
+            "practice_status",
+            "short_week",
+            "time_since_injury_weeks",
+            "recurrence_flag",
+            "team_frailty",
+            "historical_snaps",
+            "days_rest",
+        ],
+    ].reset_index(drop=True)
+    availability.sort_values(["team_id", "position", "player_id"], inplace=True)
+    return availability, frame, metrics
+
+
+def _hazard_feature_matrix(frame: pd.DataFrame) -> pd.DataFrame:
+    numeric_cols = [
+        "age",
+        "short_week",
+        "time_since_injury_weeks",
+        "recurrence_flag",
+        "team_frailty",
+        "historical_snaps",
+        "days_rest",
+    ]
+    base = frame[numeric_cols].astype(float)
+    pos_dummies = pd.get_dummies(frame["position"], prefix="pos")
+    surface_dummies = pd.get_dummies(frame["surface"], prefix="surface")
+    return pd.concat([base, pos_dummies, surface_dummies], axis=1)
+
+
+def _fit_exit_hazard(frame: pd.DataFrame, config: HealthConfig) -> pd.DataFrame:
+    prepared = frame.copy()
+    prepared["exit_exposure"] = prepared["exit_exposure"].clip(lower=1.0)
+    prepared["exit_events"] = prepared["exit_events"].clip(lower=0.0)
+
+    max_week = int(prepared["week"].max())
+    train_mask = prepared["week"] < max_week
+    if train_mask.sum() < 3:
+        # fall back to using all but the earliest record
+        ordered = prepared.sort_values(["season", "week"])
+        train_mask = ordered.index != ordered.index.min()
+        prepared = ordered
+
+    features = _hazard_feature_matrix(prepared)
+    log_rate = np.log((prepared["exit_events"] + 0.25) / (prepared["exit_exposure"] + 1.0))
+
+    model = LinearRegression()
+    model.fit(features[train_mask], log_rate[train_mask], sample_weight=prepared.loc[train_mask, "recency_weight"])
+
+    holdout_mask = prepared["week"] == max_week
+    holdout_features = features[holdout_mask]
+    if holdout_features.empty:
+        holdout_features = features.iloc[[-1]]
+        holdout_mask = features.index == holdout_features.index[0]
+
+    predicted_log_rate = model.predict(holdout_features)
+    hazard_rate = np.exp(predicted_log_rate)
+    hazard_rate = np.clip(hazard_rate, 0.0, None)
+
+    hazards = prepared.loc[holdout_mask, [
+        "player_id",
+        "team_id",
+        "season",
+        "week",
+        "age",
+        "position",
+        "short_week",
+        "time_since_injury_weeks",
+        "recurrence_flag",
+        "team_frailty",
+        "exit_events",
+        "exit_exposure",
+    ]].copy()
+    hazards["exit_hazard_rate"] = hazard_rate
+    hazards["exit_hazard_pct"] = hazards["exit_hazard_rate"] * 100.0
+    hazards["hazard_rate"] = hazards["exit_hazard_rate"]
+    hazards["hazard_pct"] = hazards["exit_hazard_pct"]
+
+    _sanity_check_hazards(hazards)
+    hazards.sort_values(["team_id", "position", "player_id"], inplace=True)
+    return hazards.reset_index(drop=True)
+
+
+def _sanity_check_hazards(hazards: pd.DataFrame) -> None:
+    if hazards.empty:
+        return
+    by_age = hazards.sort_values("age")
+    if len(by_age) >= 2 and by_age.iloc[-1]["hazard_rate"] < by_age.iloc[0]["hazard_rate"]:
+        raise ValueError("older players should not have lower exit hazard than youngest")
+    short_mask = hazards["short_week"] == 1
+    non_short_mask = hazards["short_week"] == 0
+    if short_mask.any() and non_short_mask.any():
+        if hazards.loc[short_mask, "hazard_rate"].mean() <= hazards.loc[non_short_mask, "hazard_rate"].mean():
+            raise ValueError("short-week hazard should exceed standard-week hazard")
+
+
+# ---------------------------------------------------------------------------
+# Persistence helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_artifact(df: pd.DataFrame, prefix: str, stamp: str) -> pathlib.Path:
     ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
-    out_path = ARTIFACT_DIR / f"{prefix}_{timestamp}.parquet"
+    out_path = ARTIFACT_DIR / f"{prefix}_{stamp}.parquet"
     try:
         df.to_parquet(out_path, index=False)
         return out_path
@@ -72,34 +737,35 @@ def write_artifact(df: pd.DataFrame, prefix: str, timestamp: str) -> pathlib.Pat
         return csv_path
 
 
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+
 def main() -> None:
-    """Entry point that builds stub availability and exit hazard tables."""
     start = time.time()
-    cfg = load_health_config()
+    config_map = _load_config()
+    health_cfg = HealthConfig.from_config(config_map)
 
-    recency_half_life = cfg.get("recency_half_life_weeks", 8)
-    min_events = max(int(cfg.get("min_events", 50)), 1)
+    raw_reports = _load_injury_reports(config_map)
+    prepared = _prepare_dataset(raw_reports, health_cfg)
 
-    rng_seed = min_events + int(recency_half_life)
-    rng = np.random.default_rng(rng_seed)
+    availability, enriched, metrics = _fit_availability(prepared, health_cfg)
+    hazards = _fit_exit_hazard(enriched, health_cfg)
 
-    players = build_player_pool()
-    availability = simulate_availability(players, rng)
-    exit_hazards = simulate_exit_hazards(players, rng)
-
-    timestamp = time.strftime("%Y%m%d-%H%M%S")
-    availability_path = write_artifact(availability, "availability", timestamp)
-    exit_path = write_artifact(exit_hazards, "exit_hazards", timestamp)
+    stamp = time.strftime("%Y%m%d-%H%M%S")
+    availability_path = _write_artifact(availability, "availability", stamp)
+    hazards_path = _write_artifact(hazards, "exit_hazards", stamp)
 
     duration = time.time() - start
     print(
-        "[injuries] wrote %s, %s (frailty=%s, half_life=%s, min_events=%s) in %.2fs"
+        "[injuries] wrote %s, %s (brier=%.4f, ece=%.4f, frailty=%s) in %.2fs"
         % (
             availability_path.name,
-            exit_path.name,
-            bool(cfg.get("frailty", True)),
-            recency_half_life,
-            min_events,
+            hazards_path.name,
+            metrics["brier"],
+            metrics["ece"],
+            health_cfg.use_frailty,
             duration,
         )
     )

--- a/a22a/roster/depth_logic.py
+++ b/a22a/roster/depth_logic.py
@@ -1,105 +1,395 @@
-"""Bootstrap scaffolding for roster depth and replacement planning."""
+"""Phase 12 — roster depth construction and replacement planning."""
 
 from __future__ import annotations
 
 import pathlib
+import re
 import time
-from typing import Dict, Iterable, List, Sequence
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Mapping, Optional
 
+import numpy as np
 import pandas as pd
 import yaml
 
+from a22a.units import uer
+
 CONFIG_PATH = pathlib.Path("configs/defaults.yaml")
 ARTIFACT_DIR = pathlib.Path("artifacts/roster")
-DEFAULT_POSITIONS: Sequence[str] = (
-    "QB",
-    "RB",
-    "WR",
-    "TE",
-    "LT",
-    "RT",
-    "CB",
-    "S",
-    "DL",
-    "LB",
-)
 
 
-def load_roster_config() -> Dict[str, object]:
-    """Load the roster configuration block from the defaults file."""
-    if not CONFIG_PATH.exists():
-        raise FileNotFoundError(f"missing config file: {CONFIG_PATH}")
-    config = yaml.safe_load(CONFIG_PATH.read_text()) or {}
-    return config.get("roster", {})
+@dataclass(frozen=True)
+class DepthConfig:
+    min_snaps_for_starter: int = 200
+    fallback_by_position: Dict[str, List[str]] | None = None
+    qb_replacement_penalty: float = 0.7
+    seed: int = 0
+
+    @classmethod
+    def from_config(cls, data: Mapping[str, Any]) -> "DepthConfig":
+        raw = dict(data or {})
+        seed = int(raw.get("seed", 0))
+        roster_cfg = raw.get("roster", {}) or {}
+        fallback_map = {
+            str(pos).upper(): list(values)
+            for pos, values in (roster_cfg.get("fallback_by_position", {}) or {}).items()
+        }
+        return cls(
+            min_snaps_for_starter=int(roster_cfg.get("min_snaps_for_starter", 200)),
+            fallback_by_position=fallback_map,
+            qb_replacement_penalty=float(roster_cfg.get("qb_replacement_penalty", 0.7)),
+            seed=seed,
+        )
 
 
-def build_depth_chart(
-    teams: Iterable[str],
-    positions: Sequence[str],
-    fallback_by_position: Dict[str, List[str]],
-) -> pd.DataFrame:
-    """Construct a stub depth chart with deterministic ordering and replacements."""
-    rows = []
-    for team in teams:
-        for pos in positions:
-            depth_players = [f"{team}_{pos}_{slot}" for slot in ("1", "2")]
-            for idx, player_id in enumerate(depth_players, start=1):
-                if idx < len(depth_players):
-                    replacement_player = depth_players[idx]
-                    replacement_role = "internal"
-                else:
-                    fallback_roles = fallback_by_position.get(pos, [])
-                    replacement_player = (
-                        f"{team}_{fallback_roles[0]}_1" if fallback_roles else None
-                    )
-                    replacement_role = "fallback" if replacement_player else None
-                rows.append(
-                    {
-                        "team_id": team,
-                        "position": pos,
-                        "depth_role": "starter" if idx == 1 else "primary_backup",
-                        "player_id": player_id,
-                        "depth_order": idx,
-                        "replacement_player_id": replacement_player,
-                        "replacement_type": replacement_role,
-                    }
-                )
+def _load_config(path: pathlib.Path = CONFIG_PATH) -> Mapping[str, Any]:
+    if not path.exists():
+        return {}
+    return yaml.safe_load(path.read_text()) or {}
+
+
+def _staged_root(cfg: Mapping[str, Any]) -> pathlib.Path:
+    paths = cfg.get("paths", {}) if isinstance(cfg, Mapping) else {}
+    return pathlib.Path(paths.get("staged", "./data/staged"))
+
+
+# ---------------------------------------------------------------------------
+# Sample depth chart scaffolding (used when staged inputs absent)
+# ---------------------------------------------------------------------------
+
+
+def _sample_depth_inputs() -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+    base = [
+        # Team BUF
+        {"team_id": "BUF", "position": "QB", "player_id": "BUF_QB1", "snaps": 920, "recent_snaps": 64, "depth_chart_order": 1, "is_active": True},
+        {"team_id": "BUF", "position": "QB", "player_id": "BUF_QB2", "snaps": 180, "recent_snaps": 24, "depth_chart_order": 2, "is_active": True},
+        {"team_id": "BUF", "position": "QB", "player_id": "BUF_QB3", "snaps": 60, "recent_snaps": 6, "depth_chart_order": 3, "is_active": False},
+        {"team_id": "BUF", "position": "RB", "player_id": "BUF_RB1", "snaps": 540, "recent_snaps": 42, "depth_chart_order": 1, "is_active": True},
+        {"team_id": "BUF", "position": "RB", "player_id": "BUF_RB2", "snaps": 260, "recent_snaps": 28, "depth_chart_order": 2, "is_active": True},
+        {"team_id": "BUF", "position": "RB", "player_id": "BUF_RB3", "snaps": 110, "recent_snaps": 12, "depth_chart_order": 3, "is_active": False},
+        {"team_id": "BUF", "position": "WR", "player_id": "BUF_WR1", "snaps": 710, "recent_snaps": 48, "depth_chart_order": 1, "is_active": False},
+        {"team_id": "BUF", "position": "WR", "player_id": "BUF_WR2", "snaps": 520, "recent_snaps": 52, "depth_chart_order": 2, "is_active": True},
+        {"team_id": "BUF", "position": "WR", "player_id": "BUF_WR3", "snaps": 320, "recent_snaps": 35, "depth_chart_order": 3, "is_active": True},
+        {"team_id": "BUF", "position": "WR", "player_id": "BUF_WR4", "snaps": 210, "recent_snaps": 28, "depth_chart_order": 4, "is_active": True},
+        {"team_id": "BUF", "position": "TE", "player_id": "BUF_TE1", "snaps": 430, "recent_snaps": 36, "depth_chart_order": 1, "is_active": True},
+        {"team_id": "BUF", "position": "TE", "player_id": "BUF_TE2", "snaps": 240, "recent_snaps": 22, "depth_chart_order": 2, "is_active": True},
+        {"team_id": "BUF", "position": "TE", "player_id": "BUF_TE3", "snaps": 120, "recent_snaps": 14, "depth_chart_order": 3, "is_active": False},
+        # Team KC
+        {"team_id": "KC", "position": "QB", "player_id": "KC_QB1", "snaps": 950, "recent_snaps": 65, "depth_chart_order": 1, "is_active": True},
+        {"team_id": "KC", "position": "QB", "player_id": "KC_QB2", "snaps": 210, "recent_snaps": 30, "depth_chart_order": 2, "is_active": True},
+        {"team_id": "KC", "position": "RB", "player_id": "KC_RB1", "snaps": 560, "recent_snaps": 46, "depth_chart_order": 1, "is_active": True},
+        {"team_id": "KC", "position": "RB", "player_id": "KC_RB2", "snaps": 240, "recent_snaps": 18, "depth_chart_order": 2, "is_active": False},
+        {"team_id": "KC", "position": "RB", "player_id": "KC_RB3", "snaps": 150, "recent_snaps": 20, "depth_chart_order": 3, "is_active": True},
+        {"team_id": "KC", "position": "WR", "player_id": "KC_WR1", "snaps": 690, "recent_snaps": 54, "depth_chart_order": 1, "is_active": True},
+        {"team_id": "KC", "position": "WR", "player_id": "KC_WR2", "snaps": 470, "recent_snaps": 38, "depth_chart_order": 2, "is_active": True},
+        {"team_id": "KC", "position": "WR", "player_id": "KC_WR3", "snaps": 280, "recent_snaps": 26, "depth_chart_order": 3, "is_active": True},
+        {"team_id": "KC", "position": "WR", "player_id": "KC_WR4", "snaps": 190, "recent_snaps": 24, "depth_chart_order": 4, "is_active": True},
+        {"team_id": "KC", "position": "TE", "player_id": "KC_TE1", "snaps": 560, "recent_snaps": 48, "depth_chart_order": 1, "is_active": True},
+        {"team_id": "KC", "position": "TE", "player_id": "KC_TE2", "snaps": 220, "recent_snaps": 20, "depth_chart_order": 2, "is_active": False},
+        {"team_id": "KC", "position": "TE", "player_id": "KC_TE3", "snaps": 140, "recent_snaps": 18, "depth_chart_order": 3, "is_active": True},
+    ]
+    for entry in base:
+        entry.update({"season": 2023, "week": 3})
+        rows.append(entry)
     return pd.DataFrame(rows)
 
 
+def _list_parquet(root: pathlib.Path, folder: str) -> list[pathlib.Path]:
+    target = root / folder
+    if not target.exists():
+        return []
+    return sorted(target.rglob("*.parquet"))
+
+
+def _load_depth_inputs(cfg: Mapping[str, Any]) -> pd.DataFrame:
+    staged_root = _staged_root(cfg)
+    candidates = _list_parquet(staged_root, "depth_charts")
+    frames: list[pd.DataFrame] = []
+    for path in candidates:
+        try:
+            frames.append(pd.read_parquet(path))
+        except Exception:
+            continue
+    if frames:
+        combined = pd.concat(frames, ignore_index=True)
+        if not combined.empty:
+            return combined
+    return _sample_depth_inputs()
+
+
+# ---------------------------------------------------------------------------
+# Depth ordering helpers
+# ---------------------------------------------------------------------------
+
+
+def _role_from_index(idx: int) -> str:
+    if idx == 0:
+        return "starter"
+    if idx == 1:
+        return "primary_backup"
+    if idx == 2:
+        return "secondary_backup"
+    return f"depth_{idx + 1}"
+
+
+def _assign_depth_roles(df: pd.DataFrame, config: DepthConfig) -> pd.DataFrame:
+    rows: list[pd.DataFrame] = []
+    for (team, position), group in df.groupby(["team_id", "position"], sort=False):
+        ordered_idx = (
+            group.sort_values(["depth_chart_order", "snaps"], ascending=[True, False]).index.tolist()
+        )
+        starter_candidates = group[group["snaps"] >= config.min_snaps_for_starter]
+        if starter_candidates.empty:
+            starter_index = ordered_idx[0]
+        else:
+            starter_index = starter_candidates.sort_values("snaps", ascending=False).index[0]
+        if starter_index in ordered_idx:
+            ordered_idx.remove(starter_index)
+        ordered_idx.insert(0, starter_index)
+        ordered_group = group.loc[ordered_idx].copy()
+        ordered_group["depth_order"] = range(1, len(ordered_group) + 1)
+        ordered_group["depth_role"] = ordered_group["depth_order"].apply(lambda i: _role_from_index(i - 1))
+        starter_player_id = ordered_group.iloc[0]["player_id"]
+        starter_active = bool(ordered_group.iloc[0]["is_active"])
+        active_candidates = ordered_group[ordered_group["is_active"]]
+        effective_starter_id: Optional[str]
+        effective_starter_id = active_candidates.iloc[0]["player_id"] if not active_candidates.empty else None
+        ordered_group["starter_player_id"] = starter_player_id
+        ordered_group["starter_is_active"] = starter_active
+        ordered_group["effective_starter_id"] = effective_starter_id
+        ordered_group["effective_starter_is_backup"] = effective_starter_id not in (None, starter_player_id)
+        ordered_group["lineup_id"] = f"{team}_{position}"
+        rows.append(ordered_group)
+    combined = pd.concat(rows, ignore_index=True)
+    combined.sort_values(["team_id", "position", "depth_order"], inplace=True)
+    return combined.reset_index(drop=True)
+
+
+# ---------------------------------------------------------------------------
+# Replacement logic helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_fallback_tag(tag: str) -> tuple[str, Optional[int]]:
+    tag = str(tag).upper()
+    match = re.match(r"([A-Z]+)(\d+)?", tag)
+    if not match:
+        return tag, None
+    pos = match.group(1)
+    depth = match.group(2)
+    return pos, int(depth) if depth else None
+
+
+def _team_strength_from_uer(teams: Iterable[str]) -> Dict[str, float]:
+    table = uer.run()
+    if table.is_empty():
+        return {team: 1.0 for team in teams}
+    df = pd.DataFrame(table.to_dicts())
+    if df.empty:
+        return {team: 1.0 for team in teams}
+    split = df["unit_id"].str.rsplit("_", n=2, expand=True)
+    df["uer_team"] = split[0]
+    mean_cols = [c for c in df.columns if c.endswith("_mean")]
+    available_teams = sorted(df["uer_team"].unique())
+    requested = sorted(set(teams))
+    mapping = {team: available_teams[i % len(available_teams)] for i, team in enumerate(requested)}
+    strength: Dict[str, float] = {}
+    for team in requested:
+        mapped = mapping[team]
+        subset = df[df["uer_team"] == mapped]
+        if subset.empty or not mean_cols:
+            strength[team] = 1.0
+            continue
+        base = float(subset[mean_cols].mean().mean())
+        strength[team] = 1.0 + base
+    for team in teams:
+        strength.setdefault(team, 1.0)
+    return strength
+
+
+def _find_fallback_candidate(
+    depth_table: pd.DataFrame,
+    team: str,
+    current_player: str,
+    fallback_tag: str,
+) -> Optional[pd.Series]:
+    position, depth = _parse_fallback_tag(fallback_tag)
+    candidates = depth_table[(depth_table["team_id"] == team) & (depth_table["position"] == position)]
+    if candidates.empty:
+        return None
+    candidates = candidates.sort_values("depth_order")
+    for _, row in candidates.iterrows():
+        if row["player_id"] == current_player:
+            continue
+        if depth is not None and row["depth_order"] < depth:
+            continue
+        if row["is_active"]:
+            return row
+    if depth is None:
+        for _, row in candidates.iterrows():
+            if row["player_id"] == current_player:
+                continue
+            if row["is_active"]:
+                return row
+    return None
+
+
+def _apply_replacement_logic(df: pd.DataFrame, config: DepthConfig) -> pd.DataFrame:
+    depth_df = df.copy()
+    team_strength = _team_strength_from_uer(depth_df["team_id"].unique())
+
+    depth_df["starter_uer"] = depth_df["team_id"].map(team_strength).fillna(1.0)
+    player_effective_map: Dict[int, float] = {}
+    qb_penalty_map: Dict[int, bool] = {}
+    for _, group in depth_df.groupby(["team_id", "position"], sort=False):
+        starter_snaps = float(max(group.iloc[0]["snaps"], 1.0))
+        for idx, row in group.iterrows():
+            snap_share = float(row["snaps"]) / starter_snaps if starter_snaps else 0.0
+            snap_share = min(max(snap_share, 0.0), 1.0)
+            applied_penalty = False
+            if row["depth_role"] != "starter" and row["position"] == "QB":
+                snap_share *= config.qb_replacement_penalty
+                applied_penalty = True
+            if row["depth_role"] == "starter":
+                snap_share = 1.0
+            player_effective_map[idx] = snap_share * row["starter_uer"]
+            qb_penalty_map[idx] = applied_penalty
+    depth_df["player_effective_uer"] = (
+        depth_df.index.to_series().map(player_effective_map).fillna(0.0).astype(float)
+    )
+    depth_df["qb_penalty_applied"] = (
+        depth_df.index.to_series().map(qb_penalty_map).fillna(False).astype(bool)
+    )
+    depth_df["uer_fraction"] = depth_df["player_effective_uer"] / depth_df["starter_uer"].replace(0, np.nan)
+    depth_df["uer_fraction"] = depth_df["uer_fraction"].fillna(0.0)
+
+    player_uer_lookup = depth_df.set_index("player_id")["player_effective_uer"].to_dict()
+
+    replacement_ids: list[Optional[str]] = []
+    replacement_types: list[Optional[str]] = []
+    replacement_roles: list[Optional[str]] = []
+    replacement_positions: list[Optional[str]] = []
+    replacement_is_active: list[Optional[bool]] = []
+    replacement_effective: list[float] = []
+
+    fallback_cfg = config.fallback_by_position or {}
+
+    for idx, row in depth_df.iterrows():
+        group_mask = (depth_df["team_id"] == row["team_id"]) & (depth_df["position"] == row["position"])
+        group = depth_df[group_mask].sort_values("depth_order")
+        internal_candidate = group[group["depth_order"] > row["depth_order"]]
+        internal_candidate = internal_candidate[internal_candidate["is_active"]]
+        chosen: Optional[pd.Series] = None
+        chosen_type: Optional[str] = None
+        if not internal_candidate.empty:
+            chosen = internal_candidate.iloc[0]
+            chosen_type = "depth"
+        else:
+            fallback_tags = fallback_cfg.get(row["position"], [])
+            for tag in fallback_tags:
+                candidate = _find_fallback_candidate(depth_df, row["team_id"], row["player_id"], tag)
+                if candidate is not None:
+                    chosen = candidate
+                    chosen_type = "fallback"
+                    break
+        if chosen is not None:
+            replacement_ids.append(str(chosen["player_id"]))
+            replacement_types.append(chosen_type)
+            replacement_roles.append(str(chosen.get("depth_role", None)))
+            replacement_positions.append(str(chosen.get("position", None)))
+            replacement_is_active.append(bool(chosen.get("is_active", True)))
+            replacement_effective.append(float(player_uer_lookup.get(chosen["player_id"], 0.0)))
+        else:
+            replacement_ids.append(None)
+            replacement_types.append(None)
+            replacement_roles.append(None)
+            replacement_positions.append(None)
+            replacement_is_active.append(None)
+            replacement_effective.append(0.0)
+
+    depth_df["replacement_player_id"] = replacement_ids
+    depth_df["replacement_type"] = replacement_types
+    depth_df["replacement_depth_role"] = replacement_roles
+    depth_df["replacement_position"] = replacement_positions
+    depth_df["replacement_is_active"] = replacement_is_active
+    depth_df["replacement_effective_uer"] = replacement_effective
+
+    depth_df["season"] = depth_df.get("season", 2023)
+    depth_df["week"] = depth_df.get("week", depth_df["week"].max() if "week" in depth_df else 1)
+    depth_df["season"] = depth_df["season"].astype(int)
+    depth_df["week"] = depth_df["week"].astype(int)
+    depth_df["recent_snaps"] = depth_df.get("recent_snaps", depth_df["snaps"])
+    depth_df["depth_chart_order"] = depth_df.get("depth_chart_order", depth_df["depth_order"])
+    columns = [
+        "season",
+        "week",
+        "team_id",
+        "position",
+        "lineup_id",
+        "player_id",
+        "depth_order",
+        "depth_role",
+        "depth_chart_order",
+        "snaps",
+        "recent_snaps",
+        "is_active",
+        "starter_player_id",
+        "starter_is_active",
+        "effective_starter_id",
+        "effective_starter_is_backup",
+        "starter_uer",
+        "player_effective_uer",
+        "uer_fraction",
+        "qb_penalty_applied",
+        "replacement_player_id",
+        "replacement_type",
+        "replacement_position",
+        "replacement_depth_role",
+        "replacement_is_active",
+        "replacement_effective_uer",
+    ]
+    depth_df = depth_df[columns]
+    depth_df.sort_values(["team_id", "position", "depth_order"], inplace=True)
+    depth_df.reset_index(drop=True, inplace=True)
+    return depth_df
+
+
+def _build_lineups(config: DepthConfig, cfg_map: Mapping[str, Any]) -> pd.DataFrame:
+    raw_depth = _load_depth_inputs(cfg_map)
+    if raw_depth.empty:
+        raise ValueError("depth chart input is empty")
+    assigned = _assign_depth_roles(raw_depth, config)
+    enriched = _apply_replacement_logic(assigned, config)
+    return enriched
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+
 def main() -> None:
-    """Entry point that materialises the depth chart stub to disk."""
     start = time.time()
-    cfg = load_roster_config()
+    cfg_map = _load_config()
+    config = DepthConfig.from_config(cfg_map)
 
-    fallback_by_position = cfg.get("fallback_by_position", {})
-    fallback_by_position = {
-        key: list(value) for key, value in fallback_by_position.items()
-    }
-
-    teams = [f"TEAM{idx:02d}" for idx in range(6)]
-    positions = list(DEFAULT_POSITIONS)
-    depth_chart = build_depth_chart(teams, positions, fallback_by_position)
+    lineups = _build_lineups(config, cfg_map)
 
     ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
-    timestamp = time.strftime("%Y%m%d-%H%M%S")
-    output_path = ARTIFACT_DIR / f"lineups_{timestamp}.parquet"
+    stamp = time.strftime("%Y%m%d-%H%M%S")
+    out_path = ARTIFACT_DIR / f"lineups_{stamp}.parquet"
     try:
-        depth_chart.to_parquet(output_path, index=False)
+        lineups.to_parquet(out_path, index=False)
     except Exception:
-        output_path = output_path.with_suffix(".csv")
-        depth_chart.to_csv(output_path, index=False)
+        out_path = out_path.with_suffix(".csv")
+        lineups.to_csv(out_path, index=False)
 
-    elapsed = time.time() - start
+    duration = time.time() - start
+    qb_pen = config.qb_replacement_penalty
     print(
-        "[depth] wrote %s with %d rows (min_snaps=%s, qb_penalty=%s) in %.2fs"
-        % (
-            output_path.name,
-            len(depth_chart),
-            cfg.get("min_snaps_for_starter", "n/a"),
-            cfg.get("qb_replacement_penalty", "n/a"),
-            elapsed,
-        )
+        "[depth] wrote %s with %d rows (starter_threshold=%d, qb_penalty=%.2f) in %.2fs"
+        % (out_path.name, len(lineups), config.min_snaps_for_starter, qb_pen, duration)
     )
 
 


### PR DESCRIPTION
## Summary
- replace the health bootstrap with a deterministic Phase 11 pipeline that engineers injury features, fits availability and exit-risk models, and writes calibrated artifacts
- implement Phase 12 roster depth construction that enforces starter thresholds, role-aware replacements, UER-driven penalties, and configuration fallbacks

## Testing
- `make doctor`
- `make injuries`
- `make depth`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68e59e01d008833283ef77b81620289a