### PR TITLE
Fix impact artifact filename collisions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: doctor ingest features train sim report decision uer strategy context injuries depth
+.PHONY: doctor ingest features train sim report decision uer strategy context injuries depth impact
 
 doctor:
 	python -m a22a.tools.doctor
@@ -35,3 +35,6 @@ injuries:
 
 depth:
 	python -m a22a.roster.depth_logic
+
+impact:
+	python -m a22a.impact.player_value

--- a/a22a/impact/__init__.py
+++ b/a22a/impact/__init__.py
@@ -1,0 +1,5 @@
+"""Player impact modeling stubs for Phase 13."""
+
+from .player_value import main as run_player_impact
+
+__all__ = ["run_player_impact"]

--- a/a22a/impact/player_value.py
+++ b/a22a/impact/player_value.py
@@ -1,0 +1,76 @@
+"""Bootstrap logic for Phase 13 player impact modeling."""
+
+from __future__ import annotations
+
+import pathlib
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import yaml
+
+from a22a.metrics import summarize_player_metric
+
+CONFIG_PATH = pathlib.Path("configs/defaults.yaml")
+ARTIFACT_DIR = pathlib.Path("artifacts/impact")
+
+
+def _load_config(path: pathlib.Path = CONFIG_PATH) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"Config file not found: {path}")
+    cfg = yaml.safe_load(path.read_text()) or {}
+    return cfg.get("impact", {})
+
+
+def _simulate_player(player_id: str, samples: int, ci_level: float, rng: np.random.Generator) -> dict[str, Any]:
+    win_samples = rng.normal(0.0, 0.01, size=samples)
+    margin_samples = rng.normal(0.0, 0.5, size=samples)
+    total_samples = rng.normal(0.0, 0.6, size=samples)
+
+    summary = summarize_player_metric(win_samples, margin_samples, total_samples, ci_level)
+    summary.update({
+        "player_id": player_id,
+        "samples": samples,
+    })
+    return summary
+
+
+def _write_artifact(df: pd.DataFrame) -> pathlib.Path:
+    ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S-%f")
+    nonce = uuid.uuid4().hex[:6]
+    out_path = ARTIFACT_DIR / f"player_impact_{timestamp}_{nonce}.parquet"
+    try:
+        df.to_parquet(out_path, index=False)
+    except Exception:
+        out_path = out_path.with_suffix(".csv")
+        df.to_csv(out_path, index=False)
+    return out_path
+
+
+def main() -> None:
+    start = time.time()
+    cfg = _load_config()
+
+    samples = int(cfg.get("samples_per_player", 200))
+    ci_level = float(cfg.get("ci_level", 0.90))
+    seed = int(cfg.get("seed", 13))
+
+    rng = np.random.default_rng(seed)
+    players = [f"P{i:05d}" for i in range(50)]
+
+    records = [_simulate_player(pid, samples, ci_level, rng) for pid in players]
+    df = pd.DataFrame.from_records(records)
+
+    artifact_path = _write_artifact(df)
+    duration = time.time() - start
+    print(
+        f"[impact] wrote {artifact_path.resolve().name} with {len(df)} players in {duration:.2f}s"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/a22a/metrics/__init__.py
+++ b/a22a/metrics/__init__.py
@@ -1,5 +1,13 @@
 """Shared evaluation metrics utilities."""
 
+from .impact import ImpactDelta, summarize_delta, summarize_player_metric
 from .selection import precision_at_k, selection_coverage, evaluate_selection
 
-__all__ = ["precision_at_k", "selection_coverage", "evaluate_selection"]
+__all__ = [
+    "ImpactDelta",
+    "summarize_delta",
+    "summarize_player_metric",
+    "precision_at_k",
+    "selection_coverage",
+    "evaluate_selection",
+]

--- a/a22a/metrics/impact.py
+++ b/a22a/metrics/impact.py
@@ -1,0 +1,66 @@
+"""Utility helpers for summarising player impact simulations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+import numpy as np
+
+
+@dataclass
+class ImpactDelta:
+    """Container for an impact estimate with a confidence interval."""
+
+    estimate: float
+    lower: float
+    upper: float
+
+    def as_dict(self, suffix: str) -> Mapping[str, float]:
+        return {
+            f"delta_{suffix}": self.estimate,
+            f"delta_{suffix}_ci_low": self.lower,
+            f"delta_{suffix}_ci_high": self.upper,
+        }
+
+
+def _ensure_array(samples: Iterable[float]) -> np.ndarray:
+    arr = np.asarray(list(samples), dtype=float)
+    if arr.size == 0:
+        raise ValueError("At least one sample is required to compute an impact delta")
+    return arr
+
+
+def summarize_delta(samples: Iterable[float], ci_level: float) -> ImpactDelta:
+    """Return the mean and equal-tailed CI for a set of samples."""
+
+    arr = _ensure_array(samples)
+    alpha = (1 - ci_level) / 2
+    lower = float(np.quantile(arr, alpha))
+    upper = float(np.quantile(arr, 1 - alpha))
+    estimate = float(arr.mean())
+    return ImpactDelta(estimate=estimate, lower=lower, upper=upper)
+
+
+def summarize_player_metric(win_samples: Iterable[float],
+                            margin_samples: Iterable[float],
+                            total_samples: Iterable[float],
+                            ci_level: float) -> Mapping[str, float]:
+    """Compute summary statistics for a player's simulated impact."""
+
+    win_delta = summarize_delta(win_samples, ci_level)
+    margin_delta = summarize_delta(margin_samples, ci_level)
+    total_delta = summarize_delta(total_samples, ci_level)
+
+    summary: dict[str, float] = {}
+    summary.update(win_delta.as_dict("win_pct"))
+    summary.update(margin_delta.as_dict("margin"))
+    summary.update(total_delta.as_dict("total"))
+    return summary
+
+
+__all__ = [
+    "ImpactDelta",
+    "summarize_delta",
+    "summarize_player_metric",
+]

--- a/a22a/tools/doctor.py
+++ b/a22a/tools/doctor.py
@@ -117,6 +117,7 @@ def run_doctor(ci=False) -> bool:
     print("[modules] context present:", pathlib.Path("a22a/context").exists())
     print("[modules] health present:", pathlib.Path("a22a/health").exists())
     print("[modules] roster present:", pathlib.Path("a22a/roster").exists())
+    print("[modules] impact present:", pathlib.Path("a22a/impact").exists())
 
     # Quick runtime taps (best-effort)
     tap_targets = {
@@ -126,6 +127,7 @@ def run_doctor(ci=False) -> bool:
         "context": 10,
         "injuries": 6,
         "depth": 6,
+        "impact": 90,
     }
     for label, timeout in tap_targets.items():
         try:

--- a/configs/defaults.yaml
+++ b/configs/defaults.yaml
@@ -45,3 +45,8 @@ roster:
     RB: ["RB2", "WR4", "TE2"]
     CB: ["CB4", "S3"]
   qb_replacement_penalty: 0.7
+impact:
+  samples_per_player: 200
+  ci_level: 0.90
+  max_games_per_batch: 8
+  seed: 13

--- a/tests/test_impact.py
+++ b/tests/test_impact.py
@@ -1,0 +1,38 @@
+import pathlib
+import subprocess
+import sys
+
+import pandas as pd
+
+
+def _read_artifact(path: pathlib.Path) -> pd.DataFrame:
+    if path.suffix == ".parquet":
+        try:
+            return pd.read_parquet(path)
+        except Exception:
+            path = path.with_suffix(".csv")
+    return pd.read_csv(path)
+
+
+def test_impact_runs(tmp_path):
+    outdir = pathlib.Path("artifacts/impact")
+    outdir.mkdir(parents=True, exist_ok=True)
+    before = set(outdir.glob("player_impact_*"))
+
+    result = subprocess.run(
+        [sys.executable, "-m", "a22a.impact.player_value"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "[impact]" in result.stdout
+
+    after = set(outdir.glob("player_impact_*"))
+    new_files = sorted(after - before, key=lambda p: p.stat().st_mtime)
+    assert new_files, "Expected a new impact artifact to be created"
+
+    artifact = new_files[-1]
+    df = _read_artifact(artifact)
+    required = {"player_id", "delta_win_pct", "delta_margin", "delta_total"}
+    assert required.issubset(df.columns)
+    assert len(df) > 0


### PR DESCRIPTION
## Summary
- bootstrap the player impact module with a stub simulation entrypoint and artifact writer
- add reusable impact metrics helpers and configuration defaults
- update the doctor checks and add a smoke test for the impact workflow
- ensure impact artifacts receive unique filenames to avoid collisions during repeated runs

## Testing
- pip install -e .
- make impact
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e5be8ab3308332874576af2983a9fa