### PR TITLE
phase 15 bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: doctor ingest features train sim report decision uer strategy context injuries depth impact meta
+.PHONY: doctor ingest features train sim report decision portfolio uer strategy context injuries depth impact meta
 
 doctor:
 	python -m a22a.tools.doctor
@@ -23,6 +23,9 @@ report:
 
 decision:
 	python -m a22a.decision.portfolio
+
+portfolio:
+	python -m a22a.portfolio.optimize
 
 uer:
 	python -m a22a.units.uer

--- a/a22a/metrics/__init__.py
+++ b/a22a/metrics/__init__.py
@@ -3,6 +3,7 @@
 from .impact import ImpactDelta, summarize_delta, summarize_player_metric
 from .selection import precision_at_k, selection_coverage, evaluate_selection
 from .calibration import ece, brier_score, log_loss, reliability_bins
+from .portfolio import exposure_summary, concentration_summary, turnover_summary
 
 __all__ = [
     "ImpactDelta",
@@ -15,4 +16,7 @@ __all__ = [
     "brier_score",
     "log_loss",
     "reliability_bins",
+    "exposure_summary",
+    "concentration_summary",
+    "turnover_summary",
 ]

--- a/a22a/metrics/portfolio.py
+++ b/a22a/metrics/portfolio.py
@@ -1,0 +1,52 @@
+"""Portfolio metrics stubs used during bootstrap."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def exposure_summary(df: pd.DataFrame) -> dict:
+    """Return aggregate exposure information.
+
+    Parameters
+    ----------
+    df:
+        Portfolio dataframe containing ``stake_pct`` and ``exposure_pct``.
+    """
+
+    total_pct = float(df.get("exposure_pct", pd.Series(dtype=float)).max() or 0.0)
+    total_amount = float(df.get("exposure_amount", pd.Series(dtype=float)).max() or 0.0)
+    return {
+        "total_pct": total_pct,
+        "total_amount": total_amount,
+    }
+
+
+def concentration_summary(df: pd.DataFrame) -> dict:
+    """Compute a simple Gini-style concentration measure."""
+
+    stakes = df.get("stake_pct", pd.Series(dtype=float)).astype(float)
+    if stakes.empty or stakes.sum() == 0:
+        return {"gini": 0.0}
+    sorted_stakes = stakes.sort_values().to_numpy()
+    n = len(sorted_stakes)
+    cumulative = sorted_stakes.cumsum()
+    gini = 1 - (2 / (n - 1)) * ((n - cumulative / cumulative[-1]).sum()) if n > 1 else 0.0
+    return {"gini": float(max(0.0, min(1.0, gini)))}
+
+
+def turnover_summary(previous: pd.DataFrame | None, current: pd.DataFrame) -> dict:
+    """Placeholder turnover metric that tracks changed games."""
+
+    if previous is None or previous.empty:
+        return {"changed": int(len(current))}
+    prev_ids = set(previous.get("game_id", []))
+    curr_ids = set(current.get("game_id", []))
+    return {"changed": int(len(curr_ids.symmetric_difference(prev_ids)))}
+
+
+__all__ = [
+    "exposure_summary",
+    "concentration_summary",
+    "turnover_summary",
+]

--- a/a22a/portfolio/__init__.py
+++ b/a22a/portfolio/__init__.py
@@ -1,0 +1,5 @@
+"""Portfolio optimization bootstrap module."""
+
+from . import optimize
+
+__all__ = ["optimize"]

--- a/a22a/portfolio/optimize.py
+++ b/a22a/portfolio/optimize.py
@@ -1,0 +1,127 @@
+"""Bootstrap weekly portfolio sizing logic.
+
+The real implementation will ingest calibrated probabilities and simulation
+outputs. For now we synthesize a deterministic slate and size wagers subject to
+basic Kelly-derived risk caps.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import time
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+import yaml
+
+from a22a.metrics import portfolio as portfolio_metrics
+
+
+@dataclass
+class PCfg:
+    """Portfolio configuration parsed from ``configs/defaults.yaml``."""
+
+    bankroll: float
+    kelly_fraction: float
+    max_stake_pct_per_bet: float
+    max_weekly_exposure_pct: float
+    max_game_exposure_pct: float
+    corr_guard: bool
+    corr_threshold: float
+
+
+def kelly_even(prob: float, fraction: float) -> float:
+    """Return fractional Kelly stake for an even-money payoff.
+
+    Parameters
+    ----------
+    prob:
+        Win probability.
+    fraction:
+        Fraction of full Kelly to deploy.
+    """
+
+    edge = 2 * prob - 1
+    return max(0.0, edge) * fraction
+
+
+def load_config() -> PCfg:
+    cfg = yaml.safe_load(pathlib.Path("configs/defaults.yaml").read_text())
+    return PCfg(**cfg["portfolio"])
+
+
+def synthesize_slate(n_games: int = 12) -> pd.DataFrame:
+    """Create a deterministic slate with a guaranteed coin-flip entry."""
+
+    rng = np.random.default_rng(15)
+    p_home = np.clip(0.5 + 0.2 * rng.normal(size=n_games), 0.01, 0.99)
+    p_home[0] = 0.5  # ensure abstention case for tests
+    df = pd.DataFrame({
+        "game_id": [f"G{i:03d}" for i in range(n_games)],
+        "p_home": p_home,
+    })
+    df["pick_side"] = np.where(df.p_home >= 0.5, "HOME", "AWAY")
+    df["pick_prob"] = np.where(df.p_home >= 0.5, df.p_home, 1 - df.p_home)
+    return df
+
+
+def size_portfolio(df: pd.DataFrame, pcfg: PCfg) -> pd.DataFrame:
+    exposure = 0.0
+    stakes = []
+    exposure_trace = []
+
+    for _, row in df.iterrows():
+        stake = min(
+            kelly_even(row["pick_prob"], pcfg.kelly_fraction),
+            pcfg.max_stake_pct_per_bet,
+            pcfg.max_game_exposure_pct,
+        )
+        if exposure + stake > pcfg.max_weekly_exposure_pct:
+            stake = 0.0
+        exposure += stake
+        stakes.append(round(stake, 4))
+        exposure_trace.append(round(exposure, 4))
+
+    sized = df.copy()
+    sized["stake_pct"] = stakes
+    sized["stake_amount"] = (sized["stake_pct"] * pcfg.bankroll).round(2)
+    sized["exposure_pct"] = exposure_trace
+    sized["exposure_amount"] = (sized["exposure_pct"] * pcfg.bankroll).round(2)
+    return sized
+
+
+def write_portfolio(df: pd.DataFrame, outdir: pathlib.Path) -> pathlib.Path:
+    stamp = time.strftime("%Y%m%d-%H%M%S")
+    outdir.mkdir(parents=True, exist_ok=True)
+    out = outdir / f"picks_week_{stamp}.parquet"
+    try:
+        df.to_parquet(out, index=False)
+    except Exception:
+        out = out.with_suffix(".csv")
+        df.to_csv(out, index=False)
+    return out
+
+
+def main() -> None:
+    t0 = time.time()
+    pcfg = load_config()
+    slate = synthesize_slate()
+    sized = size_portfolio(slate, pcfg)
+
+    out_path = write_portfolio(sized, pathlib.Path("artifacts/portfolio"))
+
+    exposure_stats = portfolio_metrics.exposure_summary(sized)
+    concentration_stats = portfolio_metrics.concentration_summary(sized)
+
+    elapsed = time.time() - t0
+    print(
+        f"[portfolio] wrote {out_path.name} "
+        f"exposure={exposure_stats['total_pct']:.3f} "
+        f"concentration={concentration_stats['gini']:.3f} "
+        f"in {elapsed:.2f}s"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/a22a/tools/doctor.py
+++ b/a22a/tools/doctor.py
@@ -119,10 +119,12 @@ def run_doctor(ci=False) -> bool:
     print("[modules] roster present:", pathlib.Path("a22a/roster").exists())
     print("[modules] impact present:", pathlib.Path("a22a/impact").exists())
     print("[modules] meta present:", pathlib.Path("a22a/meta").exists())
+    print("[modules] portfolio present:", pathlib.Path("a22a/portfolio").exists())
 
     # Quick runtime taps (best-effort)
     tap_targets = {
         "decision": 10,
+        "portfolio": 10,
         "uer": 10,
         "strategy": 10,
         "context": 10,

--- a/configs/defaults.yaml
+++ b/configs/defaults.yaml
@@ -23,6 +23,14 @@ decision:
   max_stake_pct_per_bet: 0.02
   max_stake_pct_per_game: 0.03
   max_weekly_exposure_pct: 0.15
+portfolio:
+  bankroll: 100000
+  kelly_fraction: 0.25
+  max_stake_pct_per_bet: 0.02
+  max_weekly_exposure_pct: 0.15
+  max_game_exposure_pct: 0.03
+  corr_guard: true
+  corr_threshold: 0.35
 uer:
   recency_half_life_weeks: 6
   ridge_lambda: 10.0

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -1,0 +1,48 @@
+import pathlib
+import subprocess
+import sys
+
+import pandas as pd
+import yaml
+
+
+def _run_portfolio():
+    result = subprocess.run(
+        [sys.executable, "-m", "a22a.portfolio.optimize"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "wrote" in result.stdout
+    outdir = pathlib.Path("artifacts/portfolio")
+    assert outdir.exists(), "portfolio artifacts directory missing"
+    outputs = sorted(outdir.glob("picks_week_*"))
+    assert outputs, "no portfolio outputs produced"
+    return outputs[-1], result.stdout
+
+
+def _read_output(path: pathlib.Path) -> pd.DataFrame:
+    if path.suffix == ".parquet":
+        try:
+            return pd.read_parquet(path)
+        except Exception:
+            return pd.read_csv(path.with_suffix(".csv"))
+    return pd.read_csv(path)
+
+
+def test_portfolio_caps_and_abstention():
+    path, _ = _run_portfolio()
+    df = _read_output(path)
+    cfg = yaml.safe_load(pathlib.Path("configs/defaults.yaml").read_text())["portfolio"]
+
+    assert "stake_pct" in df.columns
+    assert "exposure_pct" in df.columns
+
+    assert float(df["stake_pct"].max()) <= cfg["max_stake_pct_per_bet"] + 1e-6
+    assert float(df["stake_pct"].max()) <= cfg["max_game_exposure_pct"] + 1e-6
+    assert float(df["exposure_pct"].max()) <= cfg["max_weekly_exposure_pct"] + 1e-6
+
+    near_coin = df[df["pick_prob"].sub(0.5).abs() < 1e-8]
+    assert not near_coin.empty
+    assert (near_coin["stake_pct"] == 0).all()


### PR DESCRIPTION
## Summary
- add a portfolio module with config-driven sizing stub and CLI entrypoint
- provide bootstrap portfolio metrics for exposure, concentration, and turnover
- extend doctor coverage and add regression test to ensure portfolio caps are enforced

## Testing
- make doctor
- make portfolio
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e680cf13f483328cd3883329d84ed4